### PR TITLE
corrected the placing of customer deposits section

### DIFF
--- a/netsuite/Flows/SalesOrder/Fulfillment.md
+++ b/netsuite/Flows/SalesOrder/Fulfillment.md
@@ -2,7 +2,7 @@
 
 ## Fulfillment in NetSuite
 
-When a warehouse fulfills order items in Netsuite, fulfilled order information is synchronized from Netsuite to HotWax Commerce. This synchronization step ensures that orders marked as "fulfilled" in Netsuite are accurately reflected in HotWax Commerce. It ensures that the order status is consistent and updated across both systems
+When a warehouse fulfills order items in NetSuite, fulfilled order information is synchronized from NetSuite to HotWax Commerce. This synchronization step ensures that orders marked as "fulfilled" in NetSuite are accurately reflected in HotWax Commerce. It ensures that the order status is consistent and updated across both systems
 
 **Actions**
 
@@ -24,9 +24,9 @@ FTP Config: IMP_ODR_ITM_FLFLMNT
 
 ## Fulfillment in HotWax
 
-The primary difference in this context is the approach to sending fulfillment location data from HotWax Commerce to Netsuite.
+The primary difference in this context is the approach to sending fulfillment location data from HotWax Commerce to NetSuite.
 
-While fulfillment locations are indeed transmitted to Netsuite after in-store orders are fulfilled within HotWax Commerce, it's important to understand that this data transmission isn't critical for the actual fulfillment of orders. The fulfillment location data is conveyed to Netsuite once orders are fulfilled within HotWax Commerce. Its significance lies in enabling the subsequent creation of invoices, the application of payments to these invoices, and the accurate marking of orders as completed within the Netsuite system. This step occurs post-fulfillment in HotWax Commerce to ensure proper financial processing and completion of orders in Netsuite.
+While fulfillment locations are indeed transmitted to NetSuite after in-store orders are fulfilled within HotWax Commerce, it's important to understand that this data transmission isn't critical for the actual fulfillment of orders. The fulfillment location data is conveyed to NetSuite once orders are fulfilled within HotWax Commerce. Its significance lies in enabling the subsequent creation of invoices, the application of payments to these invoices, and the accurate marking of orders as completed within the NetSuite system. This step occurs post-fulfillment in HotWax Commerce to ensure proper financial processing and completion of orders in NetSuite.
 
 **Actions**
 
@@ -34,7 +34,7 @@ A scheduled job within HotWax Commerce creates a feed of outbound shipments as a
 
 *to be added*
 
-A Scheduled Script in Netsuite reads the JSON file from SFTP, allocating locations to the orders within Netsuite by updating order records. Additionally, it creates fulfillment records in Netsuite based on the HotWax Commerce shipment data using the N/Record module of Netsuite. 
+A Scheduled Script in NetSuite reads the JSON file from SFTP, allocating locations to the orders within NetSuite by updating order records. Additionally, it creates fulfillment records in NetSuite based on the HotWax Commerce shipment data using the N/Record module of NetSuite. 
 
 **SuiteScript**
 ```
@@ -43,8 +43,11 @@ HC_SC_CreateItemFulfillment
 
 Upon completion of this process, the orders transition to "pending_billing" status, signifying that they are fulfilled and ready for billing.
 
-- [x] Sync order item fulfillment details from HotWax to NetSuite
+{% hint style="info" %}
+The `HC_SC_CreateItemFulfillment` SuiteScript also generates a CSV file highlighting erroneous records found during processing and uploads the file to the SFTP server. Simultaneously, an email alert is automatically triggered to designated personnel, helping them quickly pinpoint the source of the issue and accelerating troubleshooting.
+{% endhint %}
 
+- [x] Sync order item fulfillment details from HotWax to NetSuite
 
 **Overall sync progress**
 

--- a/netsuite/Flows/SalesOrder/Invoicing.md
+++ b/netsuite/Flows/SalesOrder/Invoicing.md
@@ -1,12 +1,12 @@
 # Invoicing
 
-Generating invoices in Netsuite for orders streamlines the financial processes. This step finalizes payment transactions and accounting entries for completed orders, contributing to accurate financial reporting. This step remains the same for orders whether items are fulfilled in NetSuite or not.
+Generating invoices in NetSuite for orders streamlines the financial processes. This step finalizes payment transactions and accounting entries for completed orders, contributing to accurate financial reporting. This step remains the same for orders whether items are fulfilled in NetSuite or not.
 
 **Actions**
 
-A scheduled SuiteScript in Netsuite identifies sales orders in "pending_billing" status, which have corresponding customer deposits already created.
+A scheduled SuiteScript in NetSuite identifies sales orders in "pending_billing" status, which have corresponding customer deposits already created.
 
-Upon generating the invoice, the status of the customer deposit is marked as "Fully Applied", and the invoice status changes to "PAID IN FULL," signifying payment reception and application to the invoice. This process also ensures all necessary accounting postings are handled in Netsuite.
+Upon generating the invoice, the status of the customer deposit is marked as "Fully Applied", and the invoice status changes to "PAID IN FULL," signifying payment reception and application to the invoice. This process also ensures all necessary accounting postings are handled in NetSuite.
 
 This step has not external dependency on jobs running in HotWax Commerce. 
 
@@ -14,6 +14,9 @@ This step has not external dependency on jobs running in HotWax Commerce.
 ```
 HC_SC_CreateSalesOrderInvoice
 ```
+{% hint style="info" %}
+The `HC_SC_CreateSalesOrderInvoice` SuiteScript also generates a CSV file highlighting erroneous records found during processing and uploads the file to the SFTP server. Simultaneously, an email alert is automatically triggered to designated personnel, helping them quickly pinpoint the source of the issue and accelerating troubleshooting.
+{% endhint %}
 
 **Overall sync progress**
 

--- a/netsuite/Flows/SalesOrder/OrderAllocation.md
+++ b/netsuite/Flows/SalesOrder/OrderAllocation.md
@@ -12,7 +12,7 @@ A job in HotWax Commerce generates a CSV file containing order line items and th
 ```
 /home/{sftp-username}/netsuite/salesorder/update
 ```
-A SuiteScript in Netsuite reads the CSV file and updates fulfillment locations in sales orders by using the task.CsvImportTask  of N/task module. 
+A SuiteScript in NetSuite reads the CSV file and updates fulfillment locations in sales orders by using the task.CsvImportTask  of N/task module. 
 
 **SuiteScripts**
 

--- a/netsuite/Flows/SalesOrder/OrderApproval.md
+++ b/netsuite/Flows/SalesOrder/OrderApproval.md
@@ -261,6 +261,9 @@ A SuiteScript in NetSuite creates customer deposit records in "undeposited" stat
 ```
 HC_SC_CreateCustomerDeposit
 ```
+{% hint style="info" %}
+The `HC_SC_CreateCustomerDeposit` SuiteScript also generates a CSV file highlighting erroneous records found during processing and uploads the file to the SFTP server. Simultaneously, an email alert is automatically triggered to designated personnel, helping them quickly pinpoint the source of the issue and accelerating troubleshooting.
+{% endhint %}
 
 ## Approval of Sales Order
 

--- a/netsuite/Flows/SalesOrder/OrderApproval.md
+++ b/netsuite/Flows/SalesOrder/OrderApproval.md
@@ -198,6 +198,38 @@ FTP Config: IMP_ORDER_ITM_ATTR
 
 * [x] Sync order line items
 
+## Sync Sales Order IDs from NetSuite to HotWax Commerce
+
+This step synchronizes NetSuite sales order IDs with orders in HotWax Commerce for tracking and identification. This step enables cross-referencing and linkage between orders in both systems, paving the way for accurate tracking and management.
+
+The synchronization of Sales Order IDs from NetSuite to HotWax Commerce is a critical step as it serves as an indicator that the orders in HotWax Commerce have been successfully integrated into NetSuite. Additionally, it is an essential step for various functions, including the creation of item fulfillment, return authorization, and customer deposit records in NetSuite.
+
+**Actions**
+
+#### Export order IDs from NetSuite
+
+A Map Reduce SuiteScript in NetSuite fetches pending fulfillment orders and generates a CSV file with internal sales order IDs.
+
+**SuiteScript**
+
+```
+HC_MR_ExportedSalesOrderCSV
+```
+
+#### Import order IDs into HotWax Commerce
+
+A job in HotWax Commerce imports the CSV to associate NetSuite order IDs with corresponding orders.
+
+**Job in HotWax Commerce**
+
+```
+Order Identification
+FTP Config: IMP_ORDER_IDENT
+```
+
+* [x] Sync order ids
+
+
 ## Create Customer Deposit in NetSuite
 
 This step creates customer deposit records in NetSuite for authorized payments of sales orders. Generating a customer deposit in NetSuite is essential to represent authorized payments for orders. This step signifies the initiation of the financial transaction for orders.
@@ -229,37 +261,6 @@ A SuiteScript in NetSuite creates customer deposit records in "undeposited" stat
 ```
 HC_SC_CreateCustomerDeposit
 ```
-
-## Sync Sales Order IDs from NetSuite to HotWax Commerce
-
-This step synchronizes NetSuite sales order IDs with orders in HotWax Commerce for tracking and identification. This step enables cross-referencing and linkage between orders in both systems, paving the way for accurate tracking and management.
-
-The synchronization of Sales Order IDs from NetSuite to HotWax Commerce is a critical step as it serves as an indicator that the orders in HotWax Commerce have been successfully integrated into NetSuite. Additionally, it is an essential step for various functions, including the creation of item fulfillment, return authorization, and customer deposit records in NetSuite.
-
-**Actions**
-
-#### Export order IDs from NetSuite
-
-A Map Reduce SuiteScript in NetSuite fetches pending fulfillment orders and generates a CSV file with internal sales order IDs.
-
-**SuiteScript**
-
-```
-HC_MR_ExportedSalesOrderCSV
-```
-
-#### Import order IDs into HotWax Commerce
-
-A job in HotWax Commerce imports the CSV to associate NetSuite order IDs with corresponding orders.
-
-**Job in HotWax Commerce**
-
-```
-Order Identification
-FTP Config: IMP_ORDER_IDENT
-```
-
-* [x] Sync order ids
 
 ## Approval of Sales Order
 

--- a/netsuite/Flows/SalesOrder/ShippingMethods.md
+++ b/netsuite/Flows/SalesOrder/ShippingMethods.md
@@ -4,7 +4,7 @@ When syncing orders to NetSuite it's very important to have the correct shipping
 
 Here is a sample table of how shipping methods are mapped between Shopify HotWax and NetSuite.
 
-| #   | Shopify Value                            | HotWax ID          | Netsuite Value                                      |
+| #   | Shopify Value                            | HotWax ID          | NetSuite Value                                      |
 | --- | ---------------------------------------- | ------------------ | --------------------------------------------------- |
 | 1   | Priority Shipping (3-5 Day)              | PRI_SHP_3DAY       | Priority Shipping (3-5 Day)                         |
 | 2   | FREE 2-Day Shipping                      | FRE_2_DAY_SHP      | 2-Day Shipping                                     |

--- a/netsuite/Flows/SalesOrder/posOrders.md
+++ b/netsuite/Flows/SalesOrder/posOrders.md
@@ -24,7 +24,7 @@ Orders that match these criteria are exported to an SFTP location in a CSV file.
 
 #### Here's how POS order fields are mapped in HotWax Commerce and NetSuite
 
-<table><thead><tr><th width="152">S.No.</th><th>Fields in HotWax Commerce</th><th>Fields in NetSuite</th></tr></thead><tbody><tr><td>1</td><td>Shopify Order Name</td><td>PO #</td></tr><tr><td>3</td><td>NetSuite Order ID</td><td>POS Order Internal ID</td></tr><tr><td>5</td><td>Shopify Order ID</td><td>HC Shopify Order ID</td></tr><tr><td>6</td><td>Sales Channel</td><td>HC Sales Channel</td></tr><tr><td>7</td><td>Order Date</td><td>Date</td></tr><tr><td>8</td><td>Bill To</td><td>Customer</td></tr><tr><td>9</td><td>Product</td><td>Item</td></tr><tr><td>10</td><td>Qty</td><td>Quantity</td></tr><tr><td>13</td><td>Ship From</td><td>Location</td></tr></tbody></table>
+<table><thead><tr><th width="152">S.No.</th><th>Fields in HotWax Commerce</th><th>Fields in NetSuite</th></tr></thead><tbody><tr><td>1</td><td>Shopify Order Name</td><td>PO #</td></tr><tr><td>2</td><td>NetSuite Order ID</td><td>POS Order Internal ID</td></tr><tr><td>3</td><td>Shopify Order ID</td><td>HC Shopify Order ID</td></tr><tr><td>4</td><td>Sales Channel</td><td>HC Sales Channel</td></tr><tr><td>5</td><td>Order Date</td><td>Date*</td></tr><tr><td>6</td><td>Bill To</td><td>Customer*</td></tr><tr><td>7</td><td>Product</td><td>Item</td></tr><tr><td>8</td><td>Qty</td><td>Quantity</td></tr><tr><td>9</td><td>Ship From</td><td>Shipping Address*</td></tr></tbody></table>
 
 {% tabs %}
 {% tab title="POS Order Fields in HotWax Commerce" %}
@@ -35,6 +35,14 @@ Orders that match these criteria are exported to an SFTP location in a CSV file.
 <figure><img src="../../.gitbook/assets/POS order mapping netsuite.png" alt=""><figcaption><p>POS Order Fields Mapping in NetSuite</p></figcaption></figure>
 {% endtab %}
 {% endtabs %}
+
+#### Here's how POS order fields are mapped in HotWax Commerce and NetSuite that remains hidden in the user interface but included in the POS order CSV file
+
+<table><thead><tr><th width="170">S.No.</th><th>Fields in HotWax Commerce</th><th>Fields in NetSuite</th></tr></thead><tbody><tr><td>1</td><td>Order Item Seq ID</td><td>External Order Line ID</td></tr><tr><td>2</td><td>Price Level NetSuite</td><td>Price Level</td></tr><tr><td>3</td><td>Tax Code</td><td>Tax Code</td></tr><tr><td>4</td><td>Product Promo ID</td><td>Discount Item</td></tr><tr><td>5</td><td>Product Store External ID</td><td>Subsidiary</td></tr></tbody></table>
+
+{% hint style="danger" %}
+"\*" denotes fields that are required to be sent to NetSuite for the POS order sync to work
+{% endhint %}
 
 **SFTP Locations**
 

--- a/netsuite/Flows/purchase-orders.md
+++ b/netsuite/Flows/purchase-orders.md
@@ -97,8 +97,11 @@ In NetSuite, a scheduled script retrieves the JSON files with item receipt data 
 **SuiteScript**
 
 ```
-HC_imortPurchaseOrderReceipts
+HC_imortPurchaseOrderReceipts HC_SC_ImportPurchaseOrderReceipts
 ```
+{% hint style="info" %}
+The HC_SC_ImportPurchaseOrderReceipts SuiteScript also generates a CSV file highlighting erroneous records found during processing and uploads the file to the SFTP server. Simultaneously, an email alert is automatically triggered to designated personnel, helping them quickly pinpoint the source of the issue and accelerating troubleshooting.
+{% endhint %}
 
 ### Automated Purchase Order Status Update
 

--- a/netsuite/Flows/purchase-orders.md
+++ b/netsuite/Flows/purchase-orders.md
@@ -54,6 +54,10 @@ In HotWax Commerce, a designated job monitors the SFTP location, periodically ch
 {% endtab %}
 {% endtabs %}
 
+#### Here's how purchase order fields are mapped in NetSuite and HotWax Commerce that remains hidden in the user interface but included in the purchase order CSV file
+
+<table><thead><tr><th width="113">S.No.</th><th width="284">Fields in NetSuite</th><th>Fields in HotWax Commerce</th></tr></thead><tbody><tr><td>1</td><td>Line ID</td><td>Order Item External ID</td></tr></tbody></table>
+
 **Job in HotWax Commerce**
 
 ```

--- a/netsuite/Flows/transfer-order/TransferOrders.md
+++ b/netsuite/Flows/transfer-order/TransferOrders.md
@@ -124,8 +124,11 @@ In NetSuite, a scheduled Suite Script reads the JSON files containing Item Recei
 Import received Transfer Order file:
 
 ```
-HC_importTransferOrderReceipts
+HC_SC_ImportTransferOrderReceipts
 ```
+{% hint style="info" %}
+The HC_SC_ImportTransferOrderReceipts SuiteScript also generates a CSV file highlighting erroneous records found during processing and uploads the file to the SFTP server. Simultaneously, an email alert is automatically triggered to designated personnel, helping them quickly pinpoint the source of the issue and accelerating troubleshooting.
+{% endhint %}
 
 ### Automated Transfer Order Status Update
 

--- a/netsuite/Flows/transfer-order/TransferOrders.md
+++ b/netsuite/Flows/transfer-order/TransferOrders.md
@@ -52,6 +52,10 @@ If HotWax is only being used for receiving transfer orders, the Transfer Order f
 {% endtab %}
 {% endtabs %}
 
+#### Here's how transfer order fields are mapped in NetSuite and HotWax Commerce that remains hidden in the user interface but included in the transfer order CSV file
+
+<table><thead><tr><th width="112">S.No.</th><th width="281">Fields in NetSuite</th><th>Fields in HotWax Commerce</th></tr></thead><tbody><tr><td>1</td><td>Line ID</td><td>Shipment Item External ID</td></
+
 **SFTP Locations**
 
 NetSuite pending receipt Transfer Order file:


### PR DESCRIPTION
Initially, the customer deposits section was placed above the sync sales order IDs section, but it should be reordered and placed after the sync sales order IDs section.

Because in the actual workflow, customer deposits are generated after the sales order IDs are synced from NetSuite to HotWax Commerce.