### PR TITLE
troubleshoot documentation of Order Import and Duplicate Job scheduled

### DIFF
--- a/documents/retail-operations/order-management/troubleshoot/duplicate-job-scheduled.md
+++ b/documents/retail-operations/order-management/troubleshoot/duplicate-job-scheduled.md
@@ -1,0 +1,43 @@
+# Troubleshooting Synchronization Issues between HotWax Commerce and Shopify
+
+## Objective:
+
+This document provides a detailed guide to diagnose and resolve the exceptions caused by duplicated jobs in HotWax Commerce, which can lead to data duplication, data redundancy, and system performance issues. The goal is to ensure smooth job execution and accurate data management.
+
+## Common Scenarios:
+
+1. Overlapping jobs causing system performance issues.
+2. Data duplication or redundancy due to duplicated jobs.
+3. Interrupted job flow affecting the order life cycle.
+
+#### Scenario: Overlapping Jobs Causing system performance issues
+For example, In the Job Manager app, we have two jobs: Approve Order, which means, approves the orders in created status after checking the requisite criteria and Approve Sales Order, which acts the same as Approve Order but has a different attribute (field) values.
+Let’s suppose we have scheduled the approve orders job every 5 minutes and approve sales orders in every 15 minutes
+This collectively means we have two jobs: one is ready to run 5 minutes after the previous run, whereas the other is ready to run from now every 15 minutes. These two jobs will overlap every 15 minutes and may result in system performance issues. Additionally, the collision of these jobs may interrupt the job flow.
+
+## Step-by-Step Troubleshooting Process:
+
+#### Verify If Issue Exists:
+1. **Track the Exception:**
+   - Identify where the exception occurs or which step of the order life cycle is affected.
+2. **Analyze Job Pattern:**
+   - Determine if a process is running more than once within its scheduled frequency, indicating a duplicated job.
+
+#### Diagnose the Issue:
+1. **Access Job Manager:**
+   - Open the Job Manager app in HotWax Commerce.
+   - Navigate to the Job Manager > `Order` page (for the example provided). For example, If the duplicacy arises in another area like Brokering, navigate to the corresponding section, such as `Job Manager` > Brokering.
+2. **Identify Duplicated Jobs:**
+   - Traverse all jobs and identify those with overlapping schedules. For example, Approve Order scheduled every 5 minutes and "Approve Sales Order" scheduled every 15 minutes.
+
+#### Resolve the Issue:
+1. **Compare Jobs:**
+   - Compare both jobs to understand their functionality and attributes.
+2. **Disable Duplicated Job:**
+   - Terminate or remove the duplicated job causing the exception and the one that is outdated:
+ 	- Click on the job to open its details.
+ 	- Click the "Disable" button to deactivate the job.
+3. **Verify Job Termination:**
+   - Navigate to the pipeline page and search for the disabled job to ensure the problematic job is successfully disabled.
+
+By following these detailed steps, you can effectively troubleshoot and ensure a smooth job execution process, minimize system performance issues, and maintain accurate data management.

--- a/documents/retail-operations/order-management/troubleshoot/order-import.md
+++ b/documents/retail-operations/order-management/troubleshoot/order-import.md
@@ -1,0 +1,60 @@
+# Troubleshooting Synchronization Issues between HotWax Commerce and Shopify
+
+## Objective:
+
+This document provides a comprehensive guide to diagnose and resolve synchronization issues related to order import errors caused by special characters in notes and incorrectly formatted email fields. 
+
+## Common Scenarios:
+
+1. Order import fails in HotWax Commerce OMS due to special characters in the "Note" field. Such as 🌟 👍 😊 or miscellaneous characters.
+2. Order import fails in HotWax Commerce OMS due to incorrectly formatted email addresses. Such as name#example.com or name@#example.com, etc.
+
+
+**Common Error Messages:**
+
+   - "Rollback called in Entity Engine SQLProcessor java.lang.Exception"
+   - "E-mail address not formatted correctly, must be like: name@domain"
+
+
+## Step-by-Step Troubleshooting Process:
+
+### Verify If Issue Exists:
+1. **Access OMS:**
+   - Navigate to HotWax Commerce OMS and login with your user credentials.
+   - Go to MDM(Dashboard) / EXIM > Shopify Jobs > Import Shopify Orders.
+   - Check the Import Results in the Import Shopify Orders page for any failed records.
+
+2. **Check Shopify Logs:**
+   - Review Shopify Plus logs or feeds for specific error messages related to the failed import.
+
+### Diagnose the Issue:
+1. **Identify Failed Order:**
+   - Find the order that failed to import by looking at the error messages in OMS.
+
+2. **Download JSON File:**
+   - Append `/json` to the order URL in Shopify to download the JSON file of the failed order.
+
+3. **Inspect "Note" and "Email" Fields:**
+   - Open the JSON file and locate the note key. Check for any special characters, emojis, or miscellaneous symbols.
+   - Locate the email key and verify that the email address follows the standard format (e.g., name@domain).
+
+### Resolve the Issue:
+1. **Remove Special Characters and Correct Email Format:**
+   - Edit the JSON file to remove any special characters from the note"field.
+   - Correct the email address to adhere to the standard format.
+
+2. **Save Edited JSON:**
+   - Save the changes made to the JSON file.
+
+3. **Re-import Order:**
+   - Attempt to re-import the corrected order into HotWax Commerce.
+   - If within the job execution time (generally 15 minutes), the import order job should automatically import the order.
+   - Otherwise, manually import the order by navigating to MDM / EXIM > Shopify Jobs > Import Shopify Orders, select Shopify Config, write the Shopify Order IDs, and run the job.
+
+4. **Verify Successful Import:**
+   - Ensure the order is successfully imported without errors.
+
+
+By following these detailed steps, you can effectively troubleshoot and resolve synchronization issues between HotWax Commerce and Shopify, ensuring a smooth and error-free order import process.
+
+


### PR DESCRIPTION
Changelog: Added

Create a directory named "troubleshooting" inside retail-operation's order-management directory, which includes troubleshooting documentation named "order-import" and "duplicate-job-scheduled".