### PR TITLE
Updated Ages of status

### DIFF
--- a/analytics/data-documentation/status-item-aging.md
+++ b/analytics/data-documentation/status-item-aging.md
@@ -56,7 +56,7 @@ To optimize this process, a numeric column called "age" has been added to the `S
   | Status   | Status ID       |    Age    |
   |----------|-----------------|:---------:|
   | Created  | ORDER_CREATED    |     0     |
-  | Approved | ORDER_APPROVED   |    30     |
+  | Approved | ORDER_APPROVED   |    50     |
   | Completed| ORDER_COMPLETED  |    100    |
   | Cancelled| ORDER_CANCELLED  |    101    |
 
@@ -83,7 +83,7 @@ To optimize this process, a numeric column called "age" has been added to the `S
   |---------------|----------------------|:---------:|
   | Not received  | PAYMENT_NOT_RECEIVED  |     0     |
   | Not authorized| PAYMENT_NOT_AUTHORIZED|    10     |
-  | Authorized    | PAYMENT_AUTHORIZED    |    60     |
+  | Authorized    | PAYMENT_AUTHORIZED    |    50     |
   | Settled       | PAYMENT_SETTLED       |    100    |
   | Received      | PAYMENT_RECEIVED      |    100    |
   | Declined      | PAYMENT_DECLINED      |    101    |


### PR DESCRIPTION
CErtain ages od statuses were not right. For example, Order approved had an age of 30, but it is actually in the authorised stage of its life cycle and thus, its age should be 50.