### PR TITLE
User manual on store permissions for the cycle count

### DIFF
--- a/documents/retail-operations/SUMMARY.md
+++ b/documents/retail-operations/SUMMARY.md
@@ -92,6 +92,7 @@
   * [Review Counts](inventory-management/cycle-count/pending-review-count.md)
   * [View Closed Counts](inventory-management/cycle-count/closed-counts.md)
   * [Bulk Upload Cycle Count](inventory-management/cycle-count/bulk-import.md)
+  * [Store Permissions](inventory-management/cycle-count/store-permissions.md)
 * [Available to Promise Management](available-to-promise/README.md)
   * [Concepts](available-to-promise/concepts.md)
   * [Create Channels](available-to-promise/create-channel.md)

--- a/documents/retail-operations/inventory-management/cycle-count/store-permissions.md
+++ b/documents/retail-operations/inventory-management/cycle-count/store-permissions.md
@@ -7,7 +7,7 @@ The `Store Permissions` tab allows you to configure specific settings that contr
 The `Quantity on Hand` card includes a toggle for `Show Systemic Inventory`:
 
 - `When enabled`, the system displays the current systemic inventory, showing the expected physical quantities at each location during inventory counting.
-- `When disabled`, the systemic inventory values are hidden from store associates, ensuring they only see the manually counted inventory quantities.
+- `When disabled`, the systemic inventory values are hidden from store associates, ensuring they only see their manually counted inventory quantities.
 
 ## Force Scan Card
 

--- a/documents/retail-operations/inventory-management/cycle-count/store-permissions.md
+++ b/documents/retail-operations/inventory-management/cycle-count/store-permissions.md
@@ -1,0 +1,20 @@
+# Store Permissions
+
+The `Store Permissions` tab allows you to configure specific settings that control how store associates interact with inventory data during counting. It includes two primary cards: `Quantity on Hand` and `Force Scan`.
+
+## Quantity on Hand Card
+
+The `Quantity on Hand` card includes a toggle for `Show Systemic Inventory`:
+
+- `When enabled`, the system displays the current systemic inventory, showing the expected physical quantities at each location during inventory counting.
+- `When disabled`, the systemic inventory values are hidden from store associates, ensuring they only see the manually counted inventory quantities.
+
+## Force Scan Card
+
+The `Force Scan` card includes a toggle for `Required Barcode Scanning`:
+
+- `When enabled`, store associates are required to scan inventory barcodes in order to count inventory. Manual entry of inventory quantities is restricted to prevent errors.
+
+Additionally, the `Barcode Identifier` dropdown allows the selection of the identifier used for barcode scanning:
+
+- If the selected identifier is unavailable, the system will default to using the `Internal Name` for scanning, ensuring the process remains smooth.


### PR DESCRIPTION
The document explains how to configure settings for inventory counting, including displaying systemic inventory and requiring barcode scanning.