### PR TITLE
Removed outdated parts of the Approval Flow

### DIFF
--- a/adoc/flows/SalesOrders/OrderApproval.md
+++ b/adoc/flows/SalesOrders/OrderApproval.md
@@ -5,33 +5,46 @@ description: >-
   customer information and shipping addresses.
 ---
 
-# Order Approval
+# Order Approval Overview
 
-Order approval in ADOC involves a two-step process. Initially, the shipping address is updated through an API call, and subsequently, a new order attribute named “SHIPTO\_ADDRESS\_UPDATED” is generated with a value of “true” after the address update. Orders qualify for approval only if they possess order attributes for both a government mandated Customer ID and SHIPTO\_ADDRESS\_UPDATED. This two-criteria condition ensures that only orders with both updated customer information and shipping addresses are processed for fulfillment.
+Order approval in ADOC involves a two-step process. Initially, the shipping address is updated through a groovy script, and subsequently, new order attributes named `“SHIPTO\_ADDRESS\_UPDATED”` and `"APPROVE\_ORDER"` are generated with a value of `'true'` after the address update. Orders qualify for approval only if they possess the `“APPROVE\_ORDER”` order attribute as `‘true’`. This condition ensures that only orders with updated shipping addresses are processed for fulfillment.
 
-The municipio name in Shopify is stored as a Metafield upon order creation, which later becomes an order attribute in HotWax Commerce. To ensure accurate shipping, this order attribute must be transferred to both the City and Zipcode fields in the shipping address before sending it to the carrier.
+The municipio or canton name in Shopify is stored as note attributes, which later become order attributes in HotWax Commerce. To ensure accurate shipping, these order attributes must be updated into both the City and Zipcode fields of the shipping address before sending it to the carrier.
 
 ## Enrich shipping address
 
-HotWax updates the address by utilizing the. After a successful order address update is completed, a new order attribute “SHIP\_TO\_ADDRESS\_UPDATED” is added to orders with the corrected address.
+Orders in Hotwax are imported from Shopify in real-time via webhook, the shopify connector listens to webhook in real time and processes the Order's JSON before importing that order into OMS. HotWax updates the address by using the `OrderTransformation.groovy` service in Shopify connector.
 
-Here is a step by step process of how HotWax validates if the address values stored in order attributes are valid before adding them to the shipping address of the order.
+Here is the step-by-step process by which HotWax verifies the necessary information to update the shipping address and adds the required attributes for order approval.
+1. **Looking for Specific Attributes**: The script looks for specific attributes in the order.
+   - **taxCredit**: A flag that tells whether the customer is getting a tax credit.
+   - **municipio/canton**: (for ADOC Costa Rica): The local area or city where the order is being shipped.
+   - **customerId**: A unique identifier for the customer, necessary when tax credit is not present. If both tax credit and customerId are not found, the order does not qualify for further approval checks.
+   - **department**: (mandatory for ADOC Honduras): The state or region.
+If any of these necessary attributes are missing, an "ATTRIBUTE\_MISSING" attribute is added with the value 'true', and no other attributes are added to note attributes, nor is the shipping address updated.
+In ADOC HN, if this attribute is missing from the note attributes in order JSON then we add a `"DEPARTMENT\_NOT\_FOUND"` attribute with value 'true',  if found then the department’s geo code is updated in the `province_code` of shipping_address in order JSON. Note that whether the department is present in the note attributes or not, the `“SHIPTO\_ADDRESS\_UPDATED”` and `“APPROVE\_ORDER”` attributes will be added in either case.
 
-A schedule process identifies all orders that do not have the `SHIP_TO_ADDRESS_UPDATED` attribute.
+2. **Update the Shipping Address**  
+If all the required information is present, then the city and zip code are updated with the value of `municipio/canton` in the shipping address. 
+In ADOC HN, the department name’s corresponding geo location ID is updated in the State/Province Geo ID in Shipping Address in OMS.
+
+3. **Added necessary attributes for approval**  
+If all necessary attributes are present and the shipping address is successfully updated, new order attributes are generated:  
+    - `"SHIPTO\_ADDRESS\_UPDATED"` with a value of `'true'`,
+    - `"APPROVE\_ORDER"` with a value of `'true'`.
+With this payload, the order is created in OMS, ready to be approved.
 
 
 ## Approve Order
 
-A scheduled process checks orders for two attributes:
+A scheduled process identifies orders with the `"APPROVE\_ORDER"` attribute set to `'true’`.
 
-1. 
-2. “SHIP\_TO\_ADDRESS\_UPDATED”: (“true”)
-
-All orders that have these attributes are queued to be approved by the “Approve Orders” job.
+All orders that have these attributes are queued to be approved by the `Approve Orders` job.
 
 Job details:
 
 ```
 Approve orders
-ConfigId: IMP_APR_SALES_ORD
+Config ID: IMP_APR_SALES_ORD
+Service Name: approveSalesOrder
 ```

--- a/adoc/flows/SalesOrders/OrderApproval.md
+++ b/adoc/flows/SalesOrders/OrderApproval.md
@@ -9,72 +9,22 @@ description: >-
 
 Order approval in ADOC involves a two-step process. Initially, the shipping address is updated through an API call, and subsequently, a new order attribute named “SHIPTO\_ADDRESS\_UPDATED” is generated with a value of “true” after the address update. Orders qualify for approval only if they possess order attributes for both a government mandated Customer ID and SHIPTO\_ADDRESS\_UPDATED. This two-criteria condition ensures that only orders with both updated customer information and shipping addresses are processed for fulfillment.
 
-## Sync Shopify order metafields
-
-After an order is imported, ADOC has a job enabled for importing order metafields, under the namespace “HotwaxOrderDetails”, from Shopify by an independent job as Order Attributes in HotWax Commerce.
-
-A job in HotWax syncs order metafields from Shopify and saves them in HotWax as order attributes against that order.
-
-```
-Import Order Metafield
-```
-
-This job specifically checks order metafields under the following namespace.
-
-```
-HotwaxOrderDetails
-```
-
-This job also has an optional buffer parameter that can be used to skip orders created less than a certain duration ago. For example, setting the buffer time of 60 minutes will exclude orders that were created in the last 60 minutes.
-
-{% hint style="info" %}
-```
-Buffer time is set in minutes
-```
-{% endhint %}
-
-To verify the sync is running as expected, use the Shopify GraphQL MDM. This page is located under MDM > EXIM > Shopify Jobs > Shopify GraphQL Job.
-
-Shopify GrqphQL config
-
-> Import Shopify Order Metafields.
-
 The municipio name in Shopify is stored as a Metafield upon order creation, which later becomes an order attribute in HotWax Commerce. To ensure accurate shipping, this order attribute must be transferred to both the City and Zipcode fields in the shipping address before sending it to the carrier.
 
 ## Enrich shipping address
 
-HotWax updates the address by utilizing the `updatePostalAddressContactMech` API. After a successful order address update is completed, a new order attribute “SHIP\_TO\_ADDRESS\_UPDATED” is added to orders with the corrected address. This systematic approach ensures that the city information is correctly reflected in the shipping details provided to the carrier.
+HotWax updates the address by utilizing the. After a successful order address update is completed, a new order attribute “SHIP\_TO\_ADDRESS\_UPDATED” is added to orders with the corrected address.
 
 Here is a step by step process of how HotWax validates if the address values stored in order attributes are valid before adding them to the shipping address of the order.
 
-A schedule process identifies all orders that do not have the `SHIP_TO_ADDRESS_UPDATED` attribute. The job then checks the order for either of the following attributes:
+A schedule process identifies all orders that do not have the `SHIP_TO_ADDRESS_UPDATED` attribute.
 
-* Municipio
-* Canton
-
-It then checks the value of this attribute against the `CarrierGeoMapping` records. If the job is able to successfully identify a match in the `GeoName` column with the expected carrier ID, then it takes the matching value and adds it to the order’s postal address.
-
-Once the job receives a successful response that the address has been updated in the OMS, the order ID is added to a file containing orders with successfully updated order attributes and the value of the new attribute that is to be added to them. After a batch of orders is complete, this file is imported by HotWax, and the orders have their attributes added to them. Now when a check for order approval is run in HotWax, it will verify that all the attributes are added to the order and then the order is approved for fulfillment.
-
-### Handling values that do not have a valid carrier code mapping
-
-We created a list of Municipios and Cantons where Shopify’s mapping was not aligned with what the shipping carriers were expecting. This meant that even though customers thought they were choosing the right value, behind the scenes on Shopify the ID of their selection was not what the actual carriers were expecting.
-
-To resolve this we manually mapped all the wrong values against what the right values should be for all the countries, and then added those mappings to the `CarrierGeoMapping` table and set their carrier to the system default carrier. These records have the expected erroneous mapping in the `GeoName` column with the corrected value in the `CarrierGeoValue` column. Now that the value is corrected, when shipping labels are requested by HotWax to the carriers, it's able to send the correct carrier code.
-
-If the job finds a matching value but the carrier is “NA”, otherwise known as the system default carrier, then it updates the postal address of the order with the data in the `CarrierGeoValue` column.
-
-The process of address correction does not, however, offer a fix for CSRs misspelling municipio and canton names while creating orders. Because the error in spelling is not predictable, there is no way to auto-correct them using this mapping methodology.
-
-{% hint style="info" %}
-If an order cannot be automatically handled, it requires manual correction of its order attributes by a user for HotWax approval against this value.
-{% endhint %}
 
 ## Approve Order
 
 A scheduled process checks orders for two attributes:
 
-1. “CustomerId”: (any value)
+1. 
 2. “SHIP\_TO\_ADDRESS\_UPDATED”: (“true”)
 
 All orders that have these attributes are queued to be approved by the “Approve Orders” job.


### PR DESCRIPTION
1. Sync Shopify Order Meta Fields section removed.
2. UpdatePostalContactMech API mention.
3. Carrier Geo Mapping.
4. Handling Values that do not have valid Carrier Code Mapping.

Closes #1794