### PR TITLE
docs: remove outdated video demos from fulfillment app manual #989

### DIFF
--- a/documents/store-operations/bopis/order-page/search-order.md
+++ b/documents/store-operations/bopis/order-page/search-order.md
@@ -8,6 +8,3 @@ description: >-
 
 Several times a store associate might need to search an order to proceed with the packing process. Store associates can search the order using the search functionality by entering product names, customer names, order id to quickly find and manage fulfillment of Store Pickup Orders.\
 
-{% embed url="https://youtu.be/JW19dM-peKE" %}
-Search BOPIS Order
-{% endembed %}

--- a/documents/store-operations/fulfillment/order-lookup.md
+++ b/documents/store-operations/fulfillment/order-lookup.md
@@ -42,9 +42,6 @@ Use the filter options on the top right of the "Find Orders" page to apply filte
 
 **F. Date Range** Select a date range of the last 7 days, the last 30 days, or any custom range to view orders based on that selection. This helps store managers review and manage orders within a specific timeframe.
 
-{% embed url="https://youtu.be/VttzsAe5OxE" %}
-Video: Filter Orders
-{% endembed %}
 
 ### View Order Detail
 

--- a/documents/store-operations/fulfillment/picking-app.md
+++ b/documents/store-operations/fulfillment/picking-app.md
@@ -15,7 +15,7 @@ description: >-
 
 <figure><img src="../.gitbook/assets/1 12.png" alt=""><figcaption><p>Image: Picklist Page</p></figcaption></figure>
 
-{% embed url="https://youtu.be/WydY89mCI64" %}
+
 
 ## Picklist Details
 
@@ -27,9 +27,7 @@ Shows the details of all the picklist items in a picklist for quick scanning and
 
 Search for a picklist item by typing in the product SKU.
 
-{% embed url="https://youtu.be/sNjK3jz8-cg" %}
-Video: Search an item
-{% endembed %}
+
 
 ### Scan
 
@@ -43,12 +41,10 @@ Select the picklist items by clicking on the checkbox for the picked item.
 
 Select all the picklist items with a single click to quickly acknowledge the completion of all picklist items.
 
-{% embed url="https://youtu.be/zllJ_IKgVEw" %}
+
 
 ### Complete a Picklist
 
 Complete a picklist to initiate the packing process.
 
-{% embed url="https://youtu.be/ceLyIXTE9gk" %}
-Video: Complete picklist
-{% endembed %}
+

--- a/documents/store-operations/fulfillment/rejection-reason.md
+++ b/documents/store-operations/fulfillment/rejection-reason.md
@@ -25,7 +25,7 @@ Here's a step-by-step guide on how to use this feature:
    - **Variance Type:** Select the appropriate type that categorizes this rejection reason (e.g., Report All variance).
 5. Click `Save` to save the reason.
 
-{% embed url="https://youtu.be/sU6W-4l6luY" %} Video: Create Rejection Reason {% endembed %}
+
 
 Furthermore, you can make the following edits to the existing rejection reasons:
 
@@ -36,4 +36,4 @@ Furthermore, you can make the following edits to the existing rejection reasons:
 
 By customizing rejection reasons, users can efficiently manage orders and communicate effectively with customers.
 
-{% embed url="https://youtu.be/jH-MvETA_GY" %} Video: Edit Rejection Reason {% endembed %}
+

--- a/documents/store-operations/fulfillment/rejection.md
+++ b/documents/store-operations/fulfillment/rejection.md
@@ -12,9 +12,7 @@ The Fulfillment App allows store users to reject items from an order or complete
 
 The OMS will route the order to another facility based on product availability, customer shipping preferences, and routing rules.
 
-{% embed url="https://drive.google.com/file/d/1vInnPXJUCgavIJz28xKP-9K2Rd63DSIZ/view?usp=drive_link" %}
-Reject Single
-{% endembed %}
+
 
 ## Bulk Reject Orders
 
@@ -23,9 +21,7 @@ Stores may face issues with their fulfillment capabilities in some instances. Wh
 1. In the **Open** or **In Progress Orders** screens, click the **Reject All** icon at the top right corner.
 2. All orders in that status will be rejected and removed from the facility.
 
-{% embed url="https://drive.google.com/file/d/1zGqM5HjeZBltktMe5vJIObOrznV74lvU/view?usp=drive_link" %}
-Bulk Reject Orders
-{% endembed %}
+
 
 {% hint style="info" %}
 The Reject All button does not affect the inventory of the facility. To ensure that no new orders are brokered to the facility, set the **Online order fulfillment capacity** to **No Capacity**.
@@ -93,9 +89,7 @@ The table below lists the default rejection reasons and their assigned types, wh
 | DAMAGE           | REPORT\_VAR      | Decreases ATP inventory by the rejected quantity, while QOH remains unchanged. | Shows the product is in stock but damaged and unsellable.                                                 |
 | NO VARIANCE      | REPORT\_NO\_VAR  | Does not affect either ATP or QOH inventory.                                   | Useful for scenarios where inventory levels remain unchanged, e.g., canceled orders without stock issues. |
 
-{% embed url="https://drive.google.com/file/d/1Bj_t3o-nOzUKK95vdq8XzFWK3AJtm5uk/view?usp=drive_link" %}
-Video: Rejections in Fulfillment App
-{% endembed %}
+
 
 ## Adjust QOH Along with ATP on Rejection
 

--- a/documents/store-operations/fulfillment/troubleshooting/change-language.md
+++ b/documents/store-operations/fulfillment/troubleshooting/change-language.md
@@ -18,4 +18,4 @@ The language switching feature in the HotWax Commerce platform is designed to en
 
 By following these steps, users can ensure that their interaction with the HotWax Commerce platform is seamless and tailored to their linguistic preferences.
 
-{% embed url ="https://youtu.be/TGNPjyJGaJA" %} Change Language {% endembed %}
+

--- a/documents/system-admin/README.md
+++ b/documents/system-admin/README.md
@@ -7,80 +7,83 @@ description: >-
 
 # Launchpad
 
-**This document outlines key pages and functions within the Launchpad.**
+The Launchpad is the central hub for accessing all HotWax Commerce applications. It provides Single Sign-On (SSO), so users only need to log in once to access all associated apps without re-entering credentials.
 
-**Key items:**
+---
 
-1. Home page
-2. Application categories
-3. Application instances
+## Signing In
 
-***
+When you open the Launchpad without an active session, a **Login** button appears in the top-right corner of the home page. Select this button to begin the sign-in process.
 
-## Home page
+1. Enter your **OMS instance URL** and select **Next**.
+2. Enter your **Username** and **Password**, then select **Login**.
 
-Allows accessing all HotWax Commerce applications.
+Once signed in, selecting any app card on the home page automatically authenticates you into that application through Single Sign-On (SSO).
 
-**Characteristics:**
+{% hint style="info" %}
+In the OMS instance URL field, enter just the part before `.hotwax.io`. For example, if your instance is `company-name.hotwax.io`, enter `company-name`. The system automatically constructs the full instance URL. If you don't know your instance name, contact your system administrator.
+{% endhint %}
 
-**Single Sign-On (SSO):** Enables users to log in applications using their credentials. After the initial login in the Launchpad, they gain automatic access to all associated applications without the need to enter their login details again.
+If you select an app card without signing in first, the app redirects you back to the Launchpad login page to complete authentication before you can access it.
 
-## **Application Categories**
+---
 
-Shows how apps are categorized on basis of their characteristics.
+## Application Categories
 
-#### Orders
+Applications on the Launchpad are organized into the following categories:
 
-This category revolves around managing the orders using the three apps: BOPIS, Pre-Order Management and Fulfillment.
+### Orders
 
-* **BOPIS (Buy Online, Pickup In-Store)** HotWax Commerce’s BOPIS app enables users to handover store pick-up orders to customers.
-* **Pre-Order Management** HotWax Commerce’s Pre-Order Management app enables users to manage pre-orders and backorders, with planned future inventory to fulfill the orders.
-* **Fulfillment** HotWax Commerce's Fulfillment app enables users to pick, pack, and ship orders brokered to the stores from the OMS.
+| App | Description |
+|---|---|
+| **BOPIS** | Enables store associates to manage and handover Buy Online, Pickup In-Store orders to customers. |
+| **Fulfillment** | Enables store associates to pick, pack, and ship orders brokered to stores from the OMS. |
+| **Pre-Orders** | Enables merchandisers to manage pre-orders and backorders with planned future inventory. |
 
-#### Workflow
+### Workflow
 
-This category revolves around managing the workflow using the three apps: Threshold Management, Job Manager and Import.
+| App | Description |
+|---|---|
+| **Available to Promise** | Enables merchandisers to configure rules for computing and publishing available inventory to sales channels. |
+| **Job Manager** | Helps operations teams schedule, skip, cancel, and monitor automated jobs. |
+| **Order Routing** | Enables merchandisers to configure order routing rules that determine how and where orders are fulfilled. |
 
-* **Threshold Management** HotWax Commerce’s Threshold Management app enables merchandisers to set inventory thresholds for a group of products.
-* **Job Manager** HotWax Commerce’s Job Manager app helps the operations teams to manage jobs by scheduling new jobs, skipping or canceling scheduled jobs and finding failed jobs that need attention.
-* **Import** HotWax Commerce’s Import app enables users to import inventory and purchase orders.
+### Inventory
 
-#### Inventory
+| App | Description |
+|---|---|
+| **Receiving** | Enables store associates to manage incoming shipments, purchase orders, and return orders. |
+| **Cycle Count** | Enables stock associates to count store inventory and reconcile systematic and physical inventory. |
+| **Transfers** | Enables store associates to manage inventory transfers between facilities. |
 
-This category revolves around managing the inventory using the three apps: Receiving, Cycle Count and Picking.
+### Administration
 
-* **Receiving** HotWax Commerce’s Receiving app enables users to manage incoming shipments, purchase orders, and return orders.
-* **Cycle Count** HotWax Commerce’s Cycle Count app enables stock associates to count the store’s inventory, and reconcile systematic and physical inventory.
-* **Picking** HotWax Commerce’s Picking app enables the fulfillment team to efficiently pick order items during order fulfillment.
+| App | Description |
+|---|---|
+| **Import** | Enables users to import inventory and purchase orders. |
+| **Users** | Allows businesses to create and manage users within HotWax Commerce OMS. |
+| **Facilities** | Assists businesses in managing multiple facilities like stores and warehouses, including facility details and fulfillment options. |
+| **Company** | Enables administrators to manage company-level configurations, product stores, and Shopify shop connections. |
 
-#### Administration
-
-This category revolves around managing users and facilities using the two apps: User Management, and Facilities.
-
-* **User Management** HotWax Commerce’s User Management app allows businesses to create and manage users within the HotWax Commerce OMS.
-* **Facilities** HotWax Commerce’s Facilities app assists businesses in overseeing multiple facilities like stores and warehouses, and managing attributes like facility details and fulfillment options for each facility.
-
-***
+---
 
 ## Application Instances
 
-Users can access specific instances of the HotWax apps.
+Each app on the Launchpad can be launched in three different environments:
 
-**Instances:**
+| Instance | How to Access |
+|---|---|
+| **Production** | Select the app card. |
+| **Development (Dev)** | Select the bottom-left icon on the app card. |
+| **UAT (User Acceptance Testing)** | Select the bottom-right icon on the app card. |
 
-**1. Production Instance:** To access the production instance of an app, users can click on the respective app card.
+{% hint style="info" %}
+Some apps, such as Available to Promise, Order Routing, and Company, require a maarg instance to be configured. If maarg is not configured, these apps will display a **"Not configured"** badge and will be inaccessible.
+{% endhint %}
 
-**2. UAT (User Acceptance Testing) Instance**: Users can access the UAT instance of an app by clicking on the bottom right icon of the respective app card.
+---
 
-**3. Dev (Development) Instance:** Users can access the dev instance of an app by clicking on the bottom left icon of the respective app card.
+## Logging Out
 
-{% embed url="https://youtu.be/J2imie7z0eU" %}
-Video: Application Instance
-{% endembed %}
-
-***
-
-**Related flows:**
-
-1. [Launchpad](https://launchpad.hotwax.io/home/)
-2. [User management](https://docs.hotwax.co/documents/system-admins/administration/users/manage-user)
+1. Select your **user profile** at the top of the home page.
+2. Select **Logout** from the menu.


### PR DESCRIPTION
This PR removes outdated video demos from the fulfillment and BOPIS app user manuals. These videos were identified as likely outdated and could mislead users.

Closes #989

### Changes:
- Removed 12 video embeds from various documentation files in `documents/store-operations/fulfillment` and `documents/store-operations/bopis`.
- Included some minor documentation improvements in `documents/system-admin/README.md` (Launchpad docs update).