### PR TITLE
Deprecate checkInventory API and update guides

### DIFF
--- a/documents/integrate-with-hotwax/api/inventory/check-inventory.md
+++ b/documents/integrate-with-hotwax/api/inventory/check-inventory.md
@@ -6,6 +6,14 @@ description: >-
 
 # Check Inventory
 
+> [!WARNING]
+> This API is no longer recommended and will not be maintained for newer functionality.
+> It is recommended to use the following APIs instead:
+> - [BOPIS Check Inventory](/documents/integrate-with-hotwax/api/inventory/bopis-check-inventory.md)
+> - [Shipping Check Inventory](/documents/integrate-with-hotwax/api/inventory/shipping-check-inventory.md)
+> - [Get Online ATP](/documents/integrate-with-hotwax/api/inventory/get-online-atp.md)
+
+
 Get the stock details of the product on the specific locations. To get the stock details, you will need to call the `/checkInventory` endpoint with the POST method.
 
 ## Request

--- a/documents/integrate-with-hotwax/journeys/buy-online-pickup-in-store/bopis-pdp-experience.md
+++ b/documents/integrate-with-hotwax/journeys/buy-online-pickup-in-store/bopis-pdp-experience.md
@@ -173,7 +173,7 @@ Method: `POST`
 
 ### Step 3: Check inventory at each store allowing BOPIS
 
-For each store that allows BOPIS, use the checkBOPISInventory API to check the available to promise (ATP) inventory for the desired product. Display all the facilities with non-zero inventory numbers on the product detail page (PDP) for customers to select and place a BOPIS order.
+For each store that allows BOPIS, use the [BOPIS Check Inventory](/documents/integrate-with-hotwax/api/inventory/bopis-check-inventory.md) API to check the available to promise (ATP) inventory for the desired product. Display all the facilities with non-zero inventory numbers on the product detail page (PDP) for customers to select and place a BOPIS order.
 
 Note: If a facility has 0 inventory for the product, you can still display it for the Ship-to-store PDP experience.
 
@@ -216,10 +216,10 @@ Method: `POST`
 
 ### Handle cases when customer location is not available
 
-In case the customer's location is not available, you can display all the available store pickup locations for the product using the storeLookup API and checkInventory API. Here's how to handle this scenario:
+In case the customer's location is not available, you can display all the available store pickup locations for the product using the storeLookup API and checkBopisInventory API. Here's how to handle this scenario:
 
 * Step 1: Call the storeLookup API without passing latitude and longitude coordinates to retrieve all facilities allowing BOPIS
-* Step 2: Use the facility IDs returned in the response of the storeLookup API with the checkInventory API to get the facilities having inventory for the product
+* Step 2: Use the facility IDs returned in the response of the storeLookup API with the [BOPIS Check Inventory](/documents/integrate-with-hotwax/api/inventory/bopis-check-inventory.md) API to get the facilities having inventory for the product.
 * Step 3: Display all the locations with non-zero inventory on the PDP
 
 #### Sample

--- a/documents/learn-hotwax-oms/how-to-guides/configure-bopis.md
+++ b/documents/learn-hotwax-oms/how-to-guides/configure-bopis.md
@@ -58,7 +58,8 @@ When the inventory is received, a product’s QOH and ATP is updated in HotWax C
 
 ATP = QOH - (Reserved quantities + Safety stock + Threshold + Orders in brokering queue)
 
-For each store that allows BOPIS, HotWax Commerce uses the [checkInventory](/documents/integrate-with-hotwax/api/inventory/check-inventory) API to check the available to promise (ATP) inventory for the desired product. Display all the facilities with non-zero inventory numbers on the product detail page (PDP) for customers to select and place a BOPIS order.
+For each store that allows BOPIS, HotWax Commerce uses the [BOPIS Check Inventory](/documents/integrate-with-hotwax/api/inventory/bopis-check-inventory.md) or [Shipping Check Inventory](/documents/integrate-with-hotwax/api/inventory/shipping-check-inventory.md) API to check the available to promise (ATP) inventory for the desired product. Display all the facilities with non-zero inventory numbers on the product detail page (PDP) for customers to select and place a BOPIS order.
+
 
 ## Configure Shopify BOPIS Scripts
 

--- a/documents/learn-shopify/shopify-integration/bopis-orders/shopify-pdp-experience.md
+++ b/documents/learn-shopify/shopify-integration/bopis-orders/shopify-pdp-experience.md
@@ -20,7 +20,9 @@ This is achieved through the following steps:
 3. The HotWax Commerce BOPIS PDP app shows all the locations that offer BOPIS, sorted based on how close they are to the customer. The app also displays the store's operating hours to make the BOPIS experience smoother for the customer.
 4. To show store addresses as clickable links on the BOPIS PDP, HotWax Commerce adds the Google Maps link for each store, connects it with the store details, and displays it on the page so customers can easily open the store location in Google Maps.
 5. Customers can choose a specific location to be saved as their preferred pickup spot, known as "My Store." This saves them the hassle of having to search for their preferred pickup location every time they make an order.
-6. HotWax Commerce BOPIS PDP App on Shopify uses the 'checkInventory' API to confirm product availability and displays suitable pickup locations for that product.
+6. HotWax Commerce BOPIS PDP App on Shopify uses the [BOPIS Check Inventory](/documents/integrate-with-hotwax/api/inventory/bopis-check-inventory.md) API to confirm product availability and displays suitable pickup locations for that product.
+
+
 
 <figure><img src="../../.gitbook/assets/28-2.png" alt=""><figcaption><p><em>Fig.1 : Pickup locations on PDP</em></p></figcaption></figure>
 


### PR DESCRIPTION
This PR deprecates the `checkInventory` API documentation and updates relevant guides to recommend the modern `checkBopisInventory` and `checkShippingInventory` APIs.

Changes:
- Added deprecation notice and replacement links to `check-inventory.md`.
- Updated `shopify-pdp-experience.md`, `bopis-pdp-experience.md`, and `configure-bopis.md` to use the modern APIs.
- Following user feedback, journey/guide documents only mention the recommended APIs without cluttering the content with deprecation notices.

Closes #1211