### PR TITLE
Update settings pages categorization and fix documentation gaps (#982, #1578, #1579, #1581)

### DIFF
--- a/documents/integrate-with-hotwax/api/inbound-shipment/import.md
+++ b/documents/integrate-with-hotwax/api/inbound-shipment/import.md
@@ -33,6 +33,10 @@ description: Explore API and data feeds within the 'inbound shipment documentato
 | OUT\_TRANSFER      | OUTGOING\_SHIPMENT | Outbound Transfer Shipment |
 | PURCHASE\_RETURN   | OUTGOING\_SHIPMENT | Purchase Return Shipment   |
 
-### TBD
+### Sample Shipment File
 
-Sample Shipment file
+```csv
+external-shipment-id,product-sku,quantity,origin-facility-id,destination-facility-id,item-external-id,tracking-number,shipment-attribute,shipment-type
+12009298,26897,11,116,281,1,788944217767,EXTERNAL_ORDER_ID:TO0005374,IN_TRANSFER
+12009298,26898,5,116,281,2,788944217767,EXTERNAL_ORDER_ID:TO0005374,IN_TRANSFER
+```

--- a/documents/store-operations/SUMMARY.md
+++ b/documents/store-operations/SUMMARY.md
@@ -27,8 +27,7 @@
   * [Change Shipping Method](fulfillment/change-shipping-method.md)
   * [Troubleshooting](fulfillment/troubleshooting/README.md)
     * [Change Language](fulfillment/troubleshooting/change-language.md)
-    * [Unable to Login](fulfillment/troubleshooting/unable-to-login.md)
-* [Picking App](fulfillment/picking-app.md)
+  * [Picking App](fulfillment/picking-app.md)
 * [In-Store Returns](in-store-returns/README.md)
 
 ## Inventory

--- a/documents/store-operations/bopis/settings-page.md
+++ b/documents/store-operations/bopis/settings-page.md
@@ -8,13 +8,13 @@ description: >-
 
 Settings for the BOPIS app can be accessed by clicking on the `Settings` button on the bottom tab of the app. It displays a list of all the settings that can be configured to streamline processes and optimize BOPIS efficiency.
 
-#### Facility
+#### Facility (User-Specific)
 
 Users can use this setting to select the facility they want to operate from. Orders, inventory and other configuration data will be specific to the facility that the users select.
 
 <figure><img src="../.gitbook/assets/select-facility-setting.png" alt="" width="375"><figcaption></figcaption></figure>
 
-#### Order Edit Permissions
+#### Order Edit Permissions (Store-Specific)
 
 If an order is rejected by the store, the customer receives an email notifying them of the rejection and outlining the alternate fulfillment options that are available. Users can use toggle buttons to conveniently enable or disable permissions for various aspects of the orders that customers are allowed to edit when updating their orders on Re-route Fulfillment.
 
@@ -26,43 +26,43 @@ If an order is rejected by the store, the customer receives an email notifying t
 
 <figure><img src="../.gitbook/assets/order-edit-permissions-setting.png" alt="" width="375"><figcaption></figcaption></figure>
 
-#### Partial Order Rejection
+#### Partial Order Rejection (Store-Specific)
 
 Store managers can use this setting to control whether a BOPIS order can be partially rejected in case there is insufficient inventory of specific items at the store.
 
-#### Product Identifier
+#### Product Identifier (User-Specific)
 
 Users can choose primary and secondary product identifiers (such as product ID, product title, SKU, etc.) to view products with preferred identifiers in the app.
 
 <figure><img src="../.gitbook/assets/product-identifier-setting.png" alt="" width="375"><figcaption></figcaption></figure>
 
-#### Timezone
+#### Timezone (User-Specific)
 
 This option allows users to select an appropriate timezone to ensure consistency and optimize operations according to local time.
 
-#### Language
+#### Language (User-Specific)
 
 This option allows users to select a preferred display language for the app.
 
-#### Shipping Orders
+#### Shipping Orders (User-Specific)
 
 For stores managing both `BOPIS` and `Ship from Store` orders, switching between apps can be challenging. To optimize this process, the `Show Shipping Orders` feature can be enabled. This will allow users to view and fulfill regular orders brokered to their store by the OMS directly within the BOPIS app. Users can easily control this setting using the toggle button to enable or disable it as needed.
 
 <figure><img src="../.gitbook/assets/show-shipping-orders-setting.png" alt="" width="375"><figcaption></figcaption></figure>
 
-#### Packing Slip
+#### Packing Slip (Store-Specific)
 
 Packing slips help customers reconcile their orders against the delivered items. Store managers can use the Generate Packing Slip toggle to control whether or not packing slips are generated for orders.
 
 <figure><img src="../.gitbook/assets/packing-slip-setting.png" alt="" width="375"><figcaption></figcaption></figure>
 
-#### Track Pickers
+#### Track Pickers (Store-Specific)
 
 Store managers can assign store pickup orders to store associates and track associates who picked orders, by entering their picker IDs when packing an order. They can use the `Track Pickers` toggle to enable tracking. This is essential to manage picker commission.
 
 <figure><img src="../.gitbook/assets/track-pickers-setting.png" alt="" width="375"><figcaption></figcaption></figure>
 
-#### Notification Preferences
+#### Notification Preferences (User-Specific)
 
 Users can select the notifications they want to receive in the BOPIS app.
 

--- a/documents/store-operations/fulfillment/README.md
+++ b/documents/store-operations/fulfillment/README.md
@@ -5,6 +5,8 @@ description: >-
 
 # Fulfillment App
 
+The Fulfillment App is a specialized tool for store associates to manage the end-to-end order fulfillment process. It provides a user-friendly interface to handle assigned orders, manage store-to-store transfers, and ensure accurate shipping and delivery.
+
 ## Key Features
 
 Along with core functions like Pick, Pack, and Ship, the app includes helpful tools for both associates and managers:

--- a/documents/store-operations/fulfillment/fulfillment-setting-page.md
+++ b/documents/store-operations/fulfillment/fulfillment-setting-page.md
@@ -13,43 +13,43 @@ description: >-
 
 ## OMS
 
-### Product Store
+### Product Store (User-Specific)
 
 A Product Store represents a brand or a set of products. If your OMS is connected to multiple eCommerce brands selling different product collections, you can have separate Product Stores in HotWax Commerce.
 
 <figure><img src="../.gitbook/assets/product-store-setting.png" alt="" width="375"><figcaption><p>Select Product store</p></figcaption></figure>
 
-### Facility
+### Facility (User-Specific)
 
 The Fulfillment App allows authorized users to select a facility to operate from, determining the visibility of orders, inventory, and other configuration data.
 
 <figure><img src="../.gitbook/assets/facility-selection-modal.png" alt="" width="375"><figcaption><p>Select Facility</p></figcaption></figure>
 
-### Online Order Fulfillment
+### Online Order Fulfillment (Store-Specific)
 
 Adjust the order fulfillment capacity for your facility. If you set the fulfillment capacity to 0, new orders will not be allocated to this facility. Leave this field empty if the fulfillment capacity of this facility is unlimited. Setting fulfillment capacity to No capacity disables new orders from being allocated to this facility. Select Unlimited Capacity if this facility's fulfillment capacity is unrestricted. You can also select a custom option to set the capacity limit.
 
 <figure><img src="../.gitbook/assets/online-order-fulfillment-setting.png" alt="" width="375"><figcaption><p>Online Order Fulfillment</p></figcaption></figure>
 
-### Sell Inventory Online
+### Sell Inventory Online (Store-Specific)
 
 Determine whether the inventory of the store should be accessible for online sales or not. This setting allows you to specify whether the products available in your physical store should also be available for purchase through online channels or not. If enabled, customers browsing your online store will be able to see and purchase items from your inventory. If disabled, the products will not be listed for online sale, restricting purchases to in-store transactions only.
 
 ## App
 
-### Product Identifier
+### Product Identifier (User-Specific)
 
 This setting allows selection of a primary and secondary product identifier, such as product ID or SKU, to control how products are displayed in the app.
 
 <figure><img src="../.gitbook/assets/fulfillment-product-identifier-setting.png" alt="" width="375"><figcaption><p>Choose Product identifier</p></figcaption></figure>
 
-### Timezone
+### Timezone (User-Specific)
 
 This setting allows selecting an appropriate timezone to ensure consistency and optimize operations according to local time. 
 
 <figure><img src="../.gitbook/assets/fulfillment-timezone-setting.png" alt="" width="375"><figcaption><p>Select timezone</p></figcaption></figure>
 
-### Language
+### Language (User-Specific)
 
 Choose the preferred display language. This setting controls the language used throughout the interface.
 
@@ -61,26 +61,26 @@ Choose the preferred display language. This setting controls the language used t
 
 These settings control whether shipping labels and packing slips are printed along with each shipment by default.
 
-##### Generate Shipping Label  
+##### Generate Shipping Label (Store-Specific)
 A shipping label is used by the delivery carrier to send the package to the customer’s address. This setting controls whether shipping labels should be printed for the selected location.  
 	
-##### Generate Packing Slip  
+##### Generate Packing Slip (Store-Specific)
 A packing slip shows the list of items in an order and helps match delivered products with what was ordered. This setting allows deciding whether to print packing slips for shipments or not.
 
 <figure><img src="../.gitbook/assets/additional-documents-setting.png" alt="" width="375"><figcaption><p>Additional Documents</p></figcaption></figure>
 
-### Notification Preference
+### Notification Preference (User-Specific)
 This setting controls whether store associates receive notifications for orders awaiting fulfillment.
 
-### Force Scan
+### Force Scan (User-Specific)
 This setting enables store associates to select the barcode identifier used for scanning and specify whether scanning is required
 
-### Allow Partial Rejections
+### Allow Partial Rejections (Store-Specific)
 When [Partial Rejection is enabled](/documents/store-operations/fulfillment/rejection.md), individual items get rejected from a facility without impacting the rest of the order.
 
-### Allow Collateral Rejection
+### Allow Collateral Rejection (Store-Specific)
 [Collateral Rejection](rejection.md) helps manage situations where the product in a rejected order item is part of multiple pending orders at a facility. When enabled, rejecting an item in one order automatically rejects the same product in all other pending orders.
 
-### Affect QOH on Rejection
+### Affect QOH on Rejection (Store-Specific)
 [The Affect QOH on Rejection](/documents/store-operations/fulfillment/rejection.md) toggle provides control over inventory adjustments during order rejections.
 

--- a/documents/store-operations/fulfillment/open-orders.md
+++ b/documents/store-operations/fulfillment/open-orders.md
@@ -10,6 +10,8 @@ Whenever a new order is assigned to a store for fulfillment, store associates re
 
 ## Filters
 
+Filters help store associates narrow down the list of assigned orders to focus on those that need immediate attention or specific handling.
+
 ### Shipping Methods
 Store associates can filter orders by shipping method.  
 

--- a/documents/store-operations/fulfillment/transfer-order.md
+++ b/documents/store-operations/fulfillment/transfer-order.md
@@ -66,6 +66,8 @@ To create a new TO, tap the `+` button located in the bottom-right corner of the
 
 6. **Finalize the TO**  
    - Tap the `✓` button in the bottom right corner to finalize and create the TO.  
+
+    **Note:** Alternatively, you can use the [Upload CSV](#upload-csv-for-transfer-order) option to add products in bulk.
 {% hint style="warning" %}
 A TO cannot be edited from the Fulfillment app after this step
 {% endhint %}  


### PR DESCRIPTION
This PR addresses several documentation gaps and updates:

1. **Settings Page Updates (#982)**: Added "User-Specific" and "Store-Specific" categorization to settings in both BOPIS and Fulfillment apps.
2. **Inbound Shipment API (Resolve TBD)**: Added a concrete CSV sample for inbound shipment imports in `import.md`.
3. **Fulfillment App Documentation (#1578, #1579)**: Added missing introductory paragraphs to the Fulfillment App README and Open Orders page.
4. **Transfer Orders (#1581)**: Added a reference to the Upload CSV section in the TO creation steps.
5. **Organization (#1584)**: Reorganized the Picking App documentation under the Fulfillment App in the table of contents.

Verified all links and ensured relative linking best practices.