### PR TITLE
docs: remove Picking App from Launchpad and add Order Item Split permission (#1584, #1577)

### DIFF
--- a/documents/faq/README.md
+++ b/documents/faq/README.md
@@ -312,7 +312,11 @@ Yes, a user can be associated with different facilities within different apps. T
 
 <summary>Is there a mobile app for store associates and managers?</summary>
 
-Yes, there are several mobile apps available for store associates and managers, including: 1. \*\*HotWax Commerce's Picking App\*\*: Manages picklists. 2. \*\*HotWax Commerce's Inventory Count App\*\*: Designed for inventory management. 3. \*\*HotWax Commerce's Inventory Receiving App\*\*: Manages ASN, Purchase Orders, and Returns. 4. \*\*HotWax Commerce's BOPIS Fulfillment App\*\*: Manages Buy Online Pick-up In Store (BOPIS) functionality. 5. \*\*HotWax Commerce's Store Fulfillment App\*\*: Handles picking, packing, and shipping orders.
+Yes, there are several mobile apps available for store associates and managers, including:
+1. **HotWax Commerce's Inventory Count App**: Designed for inventory management.
+2. **HotWax Commerce's Inventory Receiving App**: Manages ASN, Purchase Orders, and Returns.
+3. **HotWax Commerce's BOPIS Fulfillment App**: Manages Buy Online Pick-up In Store (BOPIS) functionality.
+4. **HotWax Commerce's Store Fulfillment App**: Handles picking, packing, and shipping orders.
 
 </details>
 

--- a/documents/learn-hotwax-oms/business-processes/order-fulfillment.md
+++ b/documents/learn-hotwax-oms/business-processes/order-fulfillment.md
@@ -47,19 +47,7 @@ Once store managers determine the batch of orders they wish to fulfill first, th
 Store managers can also prioritize picking of an individual order item by directly initiating picking and assigning a picker for it.
 {% endhint %}
 
-HotWax Commerce provides two options using which pickers can start the picking process:
-
-**Direct Printing:** Picklists can be directly printed from the Store Fulfillment App.
-
-**QR Code Generation:** Store managers can generate QR codes for picklists from the Store Fulfillment App. The assigned picker can then scan this QR code using their mobile device and view their picklist digitally.
-
-**HotWax Commerce recommends using a digital picking process for efficient order fulfillment because it allows pickers to:**
-
-* Sort order items in the picklist based on preferred criteria, including Product Name, Bin ID, or Location Sequence ID.
-* Scan barcodes for accurate item verification.
-* View enlarged product images for easier identification.
-
-These features maximize picker efficiency and minimize errors during the picking process.
+Pickers can start the picking process by printing picklists directly from the Store Fulfillment App.
 
 ### Replace Pickers
 

--- a/documents/learn-hotwax-oms/business-processes/order-fulfillment.md
+++ b/documents/learn-hotwax-oms/business-processes/order-fulfillment.md
@@ -22,7 +22,7 @@ Once an order item is allocated, a fulfillment request is sent to the assigned f
 If an order item is allocated to a store, they are automatically reflected in the HotWax Commerce [Store Fulfillment App](/documents/store-operations/orders/fulfillment/ship-orders).
 
 {% hint style="info" %}
-HotWax Commerce provides a Store Fulfillment Suite comprising user-friendly apps such as the Store Fulfillment App and Picking App to quickly and accurately fulfill orders. These apps are specifically designed to facilitate easy adoption and minimize the learning curve for store personnel.
+HotWax Commerce provides the Store Fulfillment App to quickly and accurately fulfill orders. This app is specifically designed to facilitate easy adoption and minimize the learning curve for store personnel.
 {% endhint %}
 
 ## Manually Send Fulfillment Request
@@ -51,17 +51,15 @@ HotWax Commerce provides two options using which pickers can start the picking p
 
 **Direct Printing:** Picklists can be directly printed from the Store Fulfillment App.
 
-**QR Code Generation:** Store managers can generate QR codes for picklists from the Store Fulfillment App. The assigned picker can then scan this QR code using their mobile device and view their picklist directly in the Picking App.
+**QR Code Generation:** Store managers can generate QR codes for picklists from the Store Fulfillment App. The assigned picker can then scan this QR code using their mobile device and view their picklist digitally.
 
-**HotWax Commerce recommends using the Picking mobile app for efficient order fulfillment because it allows pickers to:**
+**HotWax Commerce recommends using a digital picking process for efficient order fulfillment because it allows pickers to:**
 
 * Sort order items in the picklist based on preferred criteria, including Product Name, Bin ID, or Location Sequence ID.
 * Scan barcodes for accurate item verification.
 * View enlarged product images for easier identification.
 
 These features maximize picker efficiency and minimize errors during the picking process.
-
-Learn more about [Picking App](/documents/store-operations/fulfillment/picking-app)
 
 ### Replace Pickers
 

--- a/documents/store-operations/README.md
+++ b/documents/store-operations/README.md
@@ -47,11 +47,10 @@ This category revolves around managing the workflow using the three apps: Thresh
 
 #### Inventory
 
-This category revolves around managing the inventory using the three apps: Receiving, Cycle Count and Picking.
+This category revolves around managing the inventory using the two apps: Receiving and Cycle Count.
 
 * **Receiving** HotWax Commerce’s Receiving app enables users to manage incoming shipments, purchase orders, and return orders.
 * **Cycle Count** HotWax Commerce’s Cycle Count app enables stock associates to count the store’s inventory, and reconcile systematic and physical inventory.
-* **Picking** HotWax Commerce’s Picking app enables the fulfillment team to efficiently pick order items during order fulfillment.
 
 #### Administration
 

--- a/documents/store-operations/SUMMARY.md
+++ b/documents/store-operations/SUMMARY.md
@@ -28,7 +28,6 @@
   * [Troubleshooting](fulfillment/troubleshooting/README.md)
     * [Change Language](fulfillment/troubleshooting/change-language.md)
     * [Unable to Login](fulfillment/troubleshooting/unable-to-login.md)
-* [Picking App](fulfillment/picking-app.md)
 * [In-Store Returns](in-store-returns/README.md)
 
 ## Inventory

--- a/documents/store-operations/bopis/settings-page.md
+++ b/documents/store-operations/bopis/settings-page.md
@@ -21,6 +21,7 @@ If an order is rejected by the store, the customer receives an email notifying t
 * **Delivery Method:** Enable or disable the permission for customers to edit the delivery method for their orders.
 * **Delivery Address:** Enable or disable the permission for customers to edit the delivery address for their orders.
 * **Pickup Location:** Enable or disable the permission for customers to edit the pickup location for their orders.
+* **Order Item Split:** Enable or disable the permission for customers to split order items for their orders.
 * **Cancel Order Before Fulfillment:** Enable or disable the permission for customers to cancel their order before it’s fulfilled.
 * **Shipment Method:** Allow the customers to edit the shipment method for their orders using a dropdown menu with available options.
 

--- a/documents/system-admin/SUMMARY.md
+++ b/documents/system-admin/SUMMARY.md
@@ -22,7 +22,6 @@
   * [Fulfillment App](administration/user-permissions/fulfillment-app.md)
   * [Job Manager App](administration/user-permissions/job-manager-app.md)
   * [Receiving App](administration/user-permissions/receiving-app.md)
-  * [Picking App](administration/user-permissions/picking-app.md)
   * [Import App](administration/user-permissions/import-app.md)
   * [Users App](administration/user-permissions/users-app.md)
   * [Facilities App](administration/user-permissions/facilities-app.md)


### PR DESCRIPTION
Resolves #1584 and #1577.

### Changes:
- **#1584 (Cleanup: Picking App Removal)**:
  - Removed Picking App from the Inventory category in `store-operations/README.md`.
  - Removed Picking App links from `SUMMARY.md` in both `store-operations` and `system-admin`.
  - Updated `learn-hotwax-oms/business-processes/order-fulfillment.md` to reflect that picking is now integrated into the Store Fulfillment App.
  - Removed Picking App from the FAQ.
- **#1577 (Completeness: Order Edit Permission)**:
  - Added "Order Item Split" permission to the Order Edit Permissions section in `store-operations/bopis/settings-page.md`.