### PR TITLE
docs: correct BOPIS POD and Fulfillment Transfer Order creation flow

### DIFF
--- a/documents/store-operations/bopis/completed-orders-tab.md
+++ b/documents/store-operations/bopis/completed-orders-tab.md
@@ -14,3 +14,21 @@ To download the packing slip, store associates can click the `Print Customer Let
 The `Order Details` page in the `Completed` Orders page shows all the main information related to the order. This includes the order ID, product details, customer name, contact details, shipping address, payment method, and payment status. There is a watch icon on the top right, which shows the order item rejection history.
 
 A timeline on the right shows key events like when the order was `created`, `approved` for fulfillment, and `picked up`. Since the order is already completed, store staff can only view the details here. No further actions, like `cancellation` or `rejection`, can be taken from this page.
+
+## Proof of Delivery (POD)
+
+Store associates can record or view Proof of Delivery (POD) details for any completed order. This feature is enabled via the **HANDOVER_PROOF** product store setting.
+
+To record POD details:
+1. Locate the order on the **Completed** tab.
+2. Click the **Proof of Delivery** button on the order card.
+3. In the pop-up, enter the following details:
+   - **Name**: Name of the person picking up the order.
+   - **ID Number**: Identity proof number.
+   - **Relation to Customer**: Relationship of the pickup person to the customer.
+   - **Phone**: Contact number.
+   - **Email**: Contact email.
+
+If the person picking up the order is the same as the billing customer, you can use the **Same as customer** checkbox to pre-fill the details from the order's billing information.
+
+Once saved, the details are recorded as a **Handover Proof** communication event, and a pickup notification email is sent to the customer. For orders with existing POD details, the button label changes to **View Proof of Delivery**.

--- a/documents/store-operations/bopis/completed-orders-tab.md
+++ b/documents/store-operations/bopis/completed-orders-tab.md
@@ -17,11 +17,11 @@ A timeline on the right shows key events like when the order was `created`, `app
 
 ## Proof of Delivery (POD)
 
-Store associates can record or view Proof of Delivery (POD) details for any completed order. This feature is enabled via the **HANDOVER_PROOF** product store setting.
+Store associates can record or view Proof of Delivery (POD) details for any completed order. This feature is enabled via the `HANDOVER_PROOF` product store setting.
 
 To record POD details:
-1. Locate the order on the **Completed** tab.
-2. Click the **Proof of Delivery** button on the order card.
+1. Locate the order on the `Completed` tab.
+2. Click the `Proof of Delivery` button on the order card.
 3. In the pop-up, enter the following details:
    - **Name**: Name of the person picking up the order.
    - **ID Number**: Identity proof number.
@@ -29,6 +29,6 @@ To record POD details:
    - **Phone**: Contact number.
    - **Email**: Contact email.
 
-If the person picking up the order is the same as the billing customer, you can use the **Same as customer** checkbox to pre-fill the details from the order's billing information.
+If the person picking up the order is the same as the billing customer, you can use the `Same as customer` checkbox to pre-fill the details from the order's billing information.
 
-Once saved, the details are recorded as a **Handover Proof** communication event, and a pickup notification email is sent to the customer. For orders with existing POD details, the button label changes to **View Proof of Delivery**.
+Once saved, the details are recorded as a Handover Proof communication event, and a pickup notification email is sent to the customer. For orders with existing POD details, the button label changes to `View Proof of Delivery`.

--- a/documents/store-operations/bopis/packed-order-tab.md
+++ b/documents/store-operations/bopis/packed-order-tab.md
@@ -10,9 +10,9 @@ The order card in the `Packed` Orders page shows the same basic details as in th
 
 There is also a `mail` icon to resend the pickup email to the customer, and a `Handover` button that is used to mark the order as `completed` once the customer picks up the order.
 
-When the **Handover** button is clicked, an alert appears to verify that the items are valid and the customer has received their order. Once the order is handed over, it moves to the **Completed** tab.
+When the `Handover` button is clicked, an alert appears to verify that the items are valid and the customer has received their order. Once the order is handed over, it moves to the `Completed` tab.
 
-Store associates can record **Proof of Delivery (POD)** details for completed orders from the **Completed Orders** page.
+Store associates can record Proof of Delivery (POD) details for completed orders from the `Completed Orders` page.
 
 ## Order Details Page
 The `Order Details` page in the `Packed` Orders page shows all the usual order information. At the top, there is a `mail` icon that lets store staff resend an email to notify the customer that their order is ready for pickup, a `watch` icon to view the order item rejection history, and a `print` icon to generate the packing slip.

--- a/documents/store-operations/bopis/packed-order-tab.md
+++ b/documents/store-operations/bopis/packed-order-tab.md
@@ -10,13 +10,9 @@ The order card in the `Packed` Orders page shows the same basic details as in th
 
 There is also a `mail` icon to resend the pickup email to the customer, and a `Handover` button that is used to mark the order as `completed` once the customer picks up the order.
 
-When the `Handover` button is clicked, a Proof of Delivery (POD) pop-up appears where the store associate records that the order has been collected either by the customer or by someone collecting it on their behalf. The associate verifies the order details and asks the person picking up the order to provide proof of identity, which can include:
+When the **Handover** button is clicked, an alert appears to verify that the items are valid and the customer has received their order. Once the order is handed over, it moves to the **Completed** tab.
 
-- Uploading an ID image
-- Providing a digital signature
-- Entering a unique pickup code
-
-The recorded details are saved and linked to the respective order. Once confirmation is saved, an automated email is sent to the customer with the order details and pickup confirmation.
+Store associates can record **Proof of Delivery (POD)** details for completed orders from the **Completed Orders** page.
 
 ## Order Details Page
 The `Order Details` page in the `Packed` Orders page shows all the usual order information. At the top, there is a `mail` icon that lets store staff resend an email to notify the customer that their order is ready for pickup, a `watch` icon to view the order item rejection history, and a `print` icon to generate the packing slip.

--- a/documents/store-operations/fulfillment/order-lookup.md
+++ b/documents/store-operations/fulfillment/order-lookup.md
@@ -28,17 +28,17 @@ HotWax Commerce enables store managers to filter orders based on specific criter
 
 ### Select Filter Criteria
 
-Use the filter options on the top right of the "Find Orders" page to apply filters. Filtering can be done based on **Brand**, **Type**, **Fulfillment Status**, **Channel**, and **Date**. Store Managers can apply these filters by checking the respective boxes or selecting from the dropdown options.
+Use the filter options on the top right of the "Find Orders" page to apply filters. Filtering can be done based on `Brand`, `Type`, `Fulfillment Status`, `Channel`, and `Date`. Store Managers can apply these filters by checking the respective boxes or selecting from the dropdown options.
  
- **A. Brand** Choose a specific Product Store from the checklist to filter orders by brand. Staff will only be able to view orders for product stores that they are linked to.
+ **A. `Brand`** Choose a specific Product Store from the checklist to filter orders by brand. Staff will only be able to view orders for product stores that they are linked to.
  
- **B. Type** Categorize orders based on their fulfillment types, such as **Store pickup** or **Ship from store**, aiding in the prioritization and management of different order categories.
+ **B. `Type`** Categorize orders based on their fulfillment types, such as `Store pickup` or `Ship from store`, aiding in the prioritization and management of different order categories.
  
- **C. Fulfillment Status** Filter orders based on their current stage (e.g., Created, Approved, Completed, or Cancelled) by selecting one or more statuses under the **Fulfillment** section.
+ **C. `Fulfillment Status`** Filter orders based on their current stage (e.g., Created, Approved, Completed, or Cancelled) by selecting one or more statuses under the `Fulfillment` section.
  
- **D. Channel** Select a sales channel from the checklist to filter orders by their origin, such as Web, POS, etc.
+ **D. `Channel`** Select a sales channel from the checklist to filter orders by their origin, such as Web, POS, etc.
  
- **E. Date** Select a date range (e.g., Last 7 days, Last 30 days) or specify a custom date range to review and manage orders within a specific timeframe.
+ **E. `Date`** Select a date range (e.g., Last 7 days, Last 30 days) or specify a custom date range to review and manage orders within a specific timeframe.
 
 ### View Order Detail
 

--- a/documents/store-operations/transfer-order/transfer-order-creation.md
+++ b/documents/store-operations/transfer-order/transfer-order-creation.md
@@ -4,56 +4,39 @@ description: How to create transfer orders in HotWax Commerce
 
 # Transfer Order Creation
 
-Transfer orders let you move inventory between locations—stores, warehouses, or between stores, using HotWax’s `Fulfillment App`.
+Transfer orders let you move inventory between locations—stores, warehouses, or between stores, using HotWax’s **Fulfillment App**.
 
 ## Create Transfer Order
 
-When inventory planners create transfer orders in NetSuite, they specify the source and destination locations. These orders land in HotWax Commerce with a **Created** status. An OMS job then **approves** them automatically, moving them to **Pending Fulfillment** for store or warehouse associates to process.
+While inventory planners can create transfer orders in NetSuite, store and warehouse associates can manually create transfers directly from the Fulfillment App.
 
-Here’s how to create a transfer order:
+1. Open the **Fulfillment App**.
+2. Go to **Transfer Orders**.
+3. Tap the **+ (FAB)** button in the bottom-right corner.
+4. In the **Create transfer order** modal:
+   - Enter a **Transfer name**.
+   - Search for and select the **Destination facility**.
+5. Tap the **Save** icon to create the order and proceed to the item addition page.
 
-1. Go to **Transfer Orders** in the Fulfillment App.  
-2. Tap the **+** button to open the **Create Transfer Order** page.
-
-## Key Fields
+## Key Fields & Actions
 
 | Field                  | Description                                                                                   |
 |------------------------|-----------------------------------------------------------------------------------------------|
-| **Order Name**         | A descriptive name for the transfer order. Tap **Edit** to update the default name.           |
-| **Destination**        | The location receiving the stock. Tap **Edit** to choose a different receiving location.      |
+| **Transfer Name**      | A descriptive name for the transfer order. Tap **Edit** to update.                            |
+| **Destination**        | The location receiving the stock. Tap **Edit** to change.                                     |
 | **Return to warehouse**| Toggle on to enable the **Fulfill Only** flow, or leave off for **Fulfill & Receive**.        |
-| **Add Items**          | Use the `Scan` segment for barcodes or `Search` for SKU/name to add products to the transfer. Use `Upload` to add items in bulk via CSV. |
+| **Add items**          | Add products to the transfer using the **Scan** or **Search** segments.                       |
 
-{% hint style="info" %}
-Once you tap **Pack and ship order**, a shipment is created and the order moves to the **Shipped** status. If you tap **Ship later**, the order is approved and saved for later processing.
-{% endhint %}
+### Adding Items
 
-## Step-by-Step Guide
+- **Scan**: Use a barcode scanner to quickly add items. If the scanner loses focus, tap **Focus scanning**.
+- **Search**: Find products by Parent name, SKU, or UPC.
+- **Manual Match**: If a scanned barcode is not found, you can manually search for the product.
 
-1. **Verify Order Name & Destination**  
-   Review the default order name and destination facility. Tap **Edit** next to either field to make changes.
-   
-2. **Configure Fulfillment Flow**  
-   Use the **Return to warehouse** toggle if you want the order to follow a **Fulfill Only** lifecycle.
-      
-3. **Add products**  
-   - **Scan**: Use the barcode scanner for quick entry. Ensure the scanner is focused by tapping **Focus scanning**.
-   - **Search**: Switch to the search segment to find products by SKU, name, or parent name.
-   - **Upload**: If enabled, use the bulk upload feature to add items via CSV.
+## Finalizing the Transfer
 
-### Bulk upload via CSV
+Once items are added, use the footer buttons to finalize the order:
 
-Use the `Upload` option from the `Add products` section when you need to add many items to a transfer order.
-
-1. Select the `Upload` segment.
-2. Upload your CSV file containing the shipment details.
-3. Map each app field to a column in your file.
-4. Select `Submit`.
-
-**Required CSV fields:**
-- `Product SKU`
-- `Quantity`
-          
-4. **Finalize the Transfer**  
-   - **Ship later**: Save the order and approve it without generating a shipment immediately.
-   - **Pack and ship order**: Approve the order, pack the items, and generate a transfer shipment.
+- **Discard order**: Cancels the creation and returns to the Transfer Orders list.
+- **Ship later**: Approves the order and saves it for later processing without immediate shipment.
+- **Pack and ship order**: Approves the order, marks the items as packed, and generates a transfer shipment.

--- a/documents/store-operations/transfer-order/transfer-order-creation.md
+++ b/documents/store-operations/transfer-order/transfer-order-creation.md
@@ -4,11 +4,11 @@ description: How to create transfer orders in HotWax Commerce
 
 # Transfer Order Creation
 
-Transfer orders let you move inventory between locations—stores, warehouses, or between stores, using HotWax’s **Fulfillment App**.
+Transfer orders let you move inventory between locations—stores, warehouses, or between stores, using HotWax’s `Fulfillment App`.
 
 ## Create Transfer Order
 
-While inventory planners can create transfer orders in NetSuite, store and warehouse associates can manually create transfers directly from the Fulfillment App.
+While inventory planners can create transfer orders in the Transfers app or external planning systems, store and warehouse associates can manually create transfers directly from the Fulfillment App.
 
 1. Open the **Fulfillment App**.
 2. Go to **Transfer Orders**.
@@ -22,21 +22,41 @@ While inventory planners can create transfer orders in NetSuite, store and wareh
 
 | Field                  | Description                                                                                   |
 |------------------------|-----------------------------------------------------------------------------------------------|
-| **Transfer Name**      | A descriptive name for the transfer order. Tap **Edit** to update.                            |
-| **Destination**        | The location receiving the stock. Tap **Edit** to change.                                     |
+| **Order Name**         | A descriptive name for the transfer order. Tap **Edit** to update the default name.           |
+| **Destination**        | The location receiving the stock. Tap **Edit** to choose a different receiving location.      |
 | **Return to warehouse**| Toggle on to enable the **Fulfill Only** flow, or leave off for **Fulfill & Receive**.        |
-| **Add items**          | Add products to the transfer using the **Scan** or **Search** segments.                       |
+| **Add Items**          | Use the `Scan` segment for barcodes or `Search` for SKU/name to add products to the transfer. Use `Upload` to add items in bulk via CSV. |
 
-### Adding Items
+{% hint style="info" %}
+Once you tap **Pack and ship order**, a shipment is created and the order moves to the **Shipped** status. If you tap **Ship later**, the order is approved and saved for later processing.
+{% endhint %}
 
-- **Scan**: Use a barcode scanner to quickly add items. If the scanner loses focus, tap **Focus scanning**.
-- **Search**: Find products by Parent name, SKU, or UPC.
-- **Manual Match**: If a scanned barcode is not found, you can manually search for the product.
+## Step-by-Step Guide
 
-## Finalizing the Transfer
+1. **Verify Order Name & Destination**  
+   Review the default order name and destination facility. Tap **Edit** next to either field to make changes.
+   
+2. **Configure Fulfillment Flow**  
+   Use the **Return to warehouse** toggle if you want the order to follow a **Fulfill Only** lifecycle.
+      
+3. **Add products**  
+   - **Scan**: Use the barcode scanner for quick entry. Ensure the scanner is focused by tapping **Focus scanning**.
+   - **Search**: Switch to the search segment to find products by SKU, name, or parent name.
+   - **Upload**: If enabled, use the bulk upload feature to add items via CSV.
 
-Once items are added, use the footer buttons to finalize the order:
+### Bulk upload via CSV
 
-- **Discard order**: Cancels the creation and returns to the Transfer Orders list.
-- **Ship later**: Approves the order and saves it for later processing without immediate shipment.
-- **Pack and ship order**: Approves the order, marks the items as packed, and generates a transfer shipment.
+Use the `Upload` option from the `Add products` section when you need to add many items to a transfer order.
+
+1. Select the `Upload` segment.
+2. Upload your CSV file containing the shipment details.
+3. Map each app field to a column in your file.
+4. Select `Submit`.
+
+**Required CSV fields:**
+- `Product SKU`
+- `Quantity`
+          
+4. **Finalize the Transfer**  
+   - **Ship later**: Save the order and approve it without generating a shipment immediately.
+   - **Pack and ship order**: Approve the order, pack the items, and generate a transfer shipment.

--- a/documents/store-operations/transfer-order/transfer-order-creation.md
+++ b/documents/store-operations/transfer-order/transfer-order-creation.md
@@ -10,37 +10,34 @@ Transfer orders let you move inventory between locations—stores, warehouses, o
 
 While inventory planners can create transfer orders in the Transfers app or external planning systems, store and warehouse associates can manually create transfers directly from the Fulfillment App.
 
-1. Open the **Fulfillment App**.
-2. Go to **Transfer Orders**.
-3. Tap the **+ (FAB)** button in the bottom-right corner.
-4. In the **Create transfer order** modal:
-   - Enter a **Transfer name**.
-   - Search for and select the **Destination facility**.
-5. Tap the **Save** icon to create the order and proceed to the item addition page.
+1. Open the `Fulfillment App`.
+2. Go to `Transfer Orders`.
+3. Tap the `+ (FAB)` button in the bottom-right corner.
+4. In the `Create transfer order` modal:
+   - Enter a `Transfer name`.
+   - Search for and select the `Destination facility`.
+5. Tap the `Save` icon to create the order and proceed to the item addition page.
 
 ## Key Fields & Actions
 
 | Field                  | Description                                                                                   |
 |------------------------|-----------------------------------------------------------------------------------------------|
-| **Order Name**         | A descriptive name for the transfer order. Tap **Edit** to update the default name.           |
-| **Destination**        | The location receiving the stock. Tap **Edit** to choose a different receiving location.      |
-| **Return to warehouse**| Toggle on to enable the **Fulfill Only** flow, or leave off for **Fulfill & Receive**.        |
+| **Order Name**         | A descriptive name for the transfer order. Tap `Edit` to update the default name.           |
+| **Destination**        | The location receiving the stock. Tap `Edit` to choose a different receiving location.      |
+| **Return to warehouse**| Toggle on to enable the `Fulfill Only` flow, or leave off for `Fulfill & Receive`.        |
 | **Add Items**          | Use the `Scan` segment for barcodes or `Search` for SKU/name to add products to the transfer. Use `Upload` to add items in bulk via CSV. |
 
 {% hint style="info" %}
-Once you tap **Pack and ship order**, a shipment is created and the order moves to the **Shipped** status. If you tap **Ship later**, the order is approved and saved for later processing.
+Once you tap `Pack and ship order`, a shipment is created and the order moves to the `Shipped` status. If you tap `Ship later`, the order is approved and saved for later processing.
 {% endhint %}
 
 ## Step-by-Step Guide
 
 1. **Verify Order Name & Destination**  
-   Review the default order name and destination facility. Tap **Edit** next to either field to make changes.
+   Review the default order name and destination facility. Tap `Edit` next to either field to make changes.
    
 2. **Configure Fulfillment Flow**  
-   Use the **Return to warehouse** toggle if you want the order to follow a **Fulfill Only** lifecycle.
-      
-3. **Add products**  
-   - **Scan**: Use the barcode scanner for quick entry. Ensure the scanner is focused by tapping **Focus scanning**.
+   - **Scan**: Use the barcode scanner for quick entry. Ensure the scanner is focused by tapping `Focus scanning`.
    - **Search**: Switch to the search segment to find products by SKU, name, or parent name.
    - **Upload**: If enabled, use the bulk upload feature to add items via CSV.
 


### PR DESCRIPTION
### Description
This PR addresses documentation accuracy issues identified during Stage 4 review for BOPIS and Transfer Order functionalities.

### Changes
- **BOPIS**:
  - `packed-order-tab.md`: Removed inaccurate references to ID images and digital signatures in the handover flow.
  - `completed-orders-tab.md`: Added a detailed "Proof of Delivery" section listing actual fields (Name, ID, Relation, Phone, Email) collected during pickup.
- **Transfer Orders**:
  - `transfer-order-creation.md`: Comprehensive update to align with the **Fulfillment App**'s manual creation flow (FAB button, modal, scanning/searching). This includes the user's manual refinements to the guide and bulk upload section.

Closes #1575, #1580.
(Note: #1583 was already addressed in a previous commit merged by the user).