### PR TITLE
Expand NetSuite product store settings documentation

### DIFF
--- a/documents/learn-netsuite/netsuite-deployment/prerequisite-syncs/productstore-settings.md
+++ b/documents/learn-netsuite/netsuite-deployment/prerequisite-syncs/productstore-settings.md
@@ -4,18 +4,18 @@ description: Configure product-store level NetSuite settings required for order,
 
 # Product Store Settings
 
-When deploying the HotWax and NetSuite integration, some settings must be configured at the product-store level so data exported from HotWax can be created correctly in NetSuite. These settings are available from the **NetSuite** page in the Company App and are used to control how orders, inventory adjustments, and fulfillment data are mapped between the two systems.
+When deploying the HotWax and NetSuite integration, some settings must be configured at the product-store level so data exported from HotWax can be created correctly in NetSuite. These settings are available from the `` `NetSuite` `` page in the **Company App** and are used to control how orders, inventory adjustments, and fulfillment data are mapped between the two systems.
 
 Use this page during implementation to verify the product store is connected to the correct NetSuite context before you start syncing live data.
 
 ## Where to configure these settings
 
 1. Open the **Company App**.
-2. Go to the **NetSuite** page.
+2. Go to the `` `NetSuite` `` page.
 3. Select the product store you want to configure.
 4. Update the settings in the relevant sections described below.
 
-For a UI walkthrough of the NetSuite page, see [Configure NetSuite Setting](/documents/system-admin/administration/company/configure-netsuite-setting.md).
+For a UI walkthrough of the `` `NetSuite` `` page, see [Configure NetSuite Setting](/documents/system-admin/administration/company/configure-netsuite-setting.md).
 
 ## Product Store
 
@@ -29,7 +29,7 @@ This mapping tells HotWax which NetSuite subsidiary context to use for the selec
 - Enter the corresponding NetSuite subsidiary ID.
 - Save the mapping.
 
-If one HotWax product store needs to work with multiple subsidiaries, configure all required subsidiary IDs for that store from the NetSuite page.
+If one HotWax product store needs to work with multiple subsidiaries, configure all required subsidiary IDs for that store from the `` `NetSuite` `` page.
 
 ## Product and Inventory
 
@@ -61,7 +61,7 @@ Shipping methods used in HotWax must be mapped to NetSuite shipment method IDs.
 - Enter the corresponding NetSuite shipment method ID.
 - Save the mapping.
 
-For more detail, see [Shipping Methods](/documents/learn-netsuite/synchronization-flows/integration-mappings/shipping-methods.md).
+For more detail, see [Shipping Methods](../../synchronization-flows/integration-mappings/shipping-methods.md).
 
 ### Payment Method
 
@@ -73,7 +73,7 @@ Payment methods must be mapped before order sync so NetSuite receives a valid pa
 
 Unmapped payment methods can cause order sync failures.
 
-For more detail, see [Payment Methods](/documents/learn-netsuite/synchronization-flows/integration-mappings/payment-methods.md).
+For more detail, see [Payment Methods](../../synchronization-flows/integration-mappings/payment-methods.md).
 
 ### Price Levels
 
@@ -90,7 +90,7 @@ To configure:
 - Select the NetSuite price level ID, or choose `Custom`.
 - Save the setting.
 
-For more detail, see [Price Levels](/documents/learn-netsuite/synchronization-flows/integration-mappings/price-levels.md).
+For more detail, see [Price Levels](../../synchronization-flows/integration-mappings/price-levels.md).
 
 ### Discount Mapping
 
@@ -137,8 +137,8 @@ To reduce sync failures during setup, configure these settings in this order:
 
 These settings work together with other NetSuite deployment prerequisites:
 
-- [SFTP Locations](/documents/learn-netsuite/netsuite-deployment/prerequisite-syncs/sftp-locations.md)
-- [Shipping Methods](/documents/learn-netsuite/netsuite-deployment/prerequisite-syncs/shipping-methods.md)
-- [Payment Methods](/documents/learn-netsuite/netsuite-deployment/prerequisite-syncs/payment-methods.md)
-- [Price Level](/documents/learn-netsuite/netsuite-deployment/prerequisite-syncs/price-level.md)
-- [Configure NetSuite Setting](/documents/system-admin/administration/company/configure-netsuite-setting.md)
+- [SFTP Locations](./sftp-locations.md)
+- [Shipping Methods](./shipping-methods.md)
+- [Payment Methods](./payment-methods.md)
+- [Price Level](./price-level.md)
+- [Configure NetSuite Setting](../../../system-admin/administration/company/configure-netsuite-setting.md)

--- a/documents/learn-netsuite/netsuite-deployment/prerequisite-syncs/productstore-settings.md
+++ b/documents/learn-netsuite/netsuite-deployment/prerequisite-syncs/productstore-settings.md
@@ -1,144 +1,46 @@
 ---
-description: Configure product-store level NetSuite settings required for order, inventory, and fulfillment syncs.
+description: Configure Product Store setting enums used during NetSuite deployment.
 ---
 
 # Product Store Settings
 
-When deploying the HotWax and NetSuite integration, some settings must be configured at the product-store level so data exported from HotWax can be created correctly in NetSuite. These settings are available from the `` `NetSuite` `` page in the **Company App** and are used to control how orders, inventory adjustments, and fulfillment data are mapped between the two systems.
+In HotWax, Product Store settings are key-value configurations stored as `ProductStoreSetting` records. These settings are different from the mappings configured on the **NetSuite** page in the Company App.
 
-Use this page during implementation to verify the product store is connected to the correct NetSuite context before you start syncing live data.
+Use this page only for settings that are implemented as Product Store setting enums and are relevant to the NetSuite integration.
 
-## Where to configure these settings
+## What belongs on this page
 
-1. Open the **Company App**.
-2. Go to the `` `NetSuite` `` page.
-3. Select the product store you want to configure.
-4. Update the settings in the relevant sections described below.
+The following configuration is a Product Store setting used by the NetSuite integration:
 
-For a UI walkthrough of the `` `NetSuite` `` page, see [Configure NetSuite Setting](/documents/system-admin/administration/company/configure-netsuite-setting.md).
+| Setting ID | Purpose |
+| --- | --- |
+| `PRICE_LEVEL_NETSUITE` | Defines which NetSuite price level HotWax should send when syncing orders. |
 
-## Product Store
+## Price level setting
 
-Each HotWax product store must be linked to the NetSuite subsidiary it belongs to.
+Use `PRICE_LEVEL_NETSUITE` to control the price level value sent from HotWax to NetSuite during order sync.
 
-### NetSuite Subsidiary ID
+Example XML:
 
-This mapping tells HotWax which NetSuite subsidiary context to use for the selected product store.
+```xml
+<Enumeration description="Price Level to be sent into Netsuite" enumId="PRICE_LEVEL_NETSUITE" enumName="Price Level Netsuite" enumTypeId="PROD_STR_STNG" />
+<ProductStoreSetting fromDate="2023-06-22 05:24:22.82" productStoreId="STORE" settingTypeEnumId="PRICE_LEVEL_NETSUITE" settingValue="Base Price (MSRP)" />
+```
 
-- Select the product store.
-- Enter the corresponding NetSuite subsidiary ID.
-- Save the mapping.
+You can update the `settingValue` whenever a different NetSuite price level should be used.
 
-If one HotWax product store needs to work with multiple subsidiaries, configure all required subsidiary IDs for that store from the `` `NetSuite` `` page.
+For implementation details, see [Price Level](/documents/learn-netsuite/netsuite-deployment/prerequisite-syncs/price-level.md).
 
-## Product and Inventory
+## Related NetSuite mappings
 
-These settings control how inventory-related data is posted to NetSuite.
+The following NetSuite deployment configurations are required, but they are not Product Store settings:
 
-### Inventory Variance
+- NetSuite subsidiary mapping
+- Shipping method mapping
+- Payment method mapping
+- Discount mapping
+- Department mapping
+- Sales channel mapping
+- Inventory variance mapping
 
-Inventory variance mappings define how HotWax sends approved inventory adjustments to NetSuite.
-
-Configure the following for each variance reason that should sync:
-
-- Inventory variance reason
-- NetSuite inventory adjustment reason ID
-- NetSuite facility ID, if that variance should post against a specific location
-
-If a retailer uses transfer-style handling for some variance reasons, the facility mapping can be used so the transaction is processed in the correct NetSuite context.
-
-To understand how inventory variance sync works end to end, see [Cycle Count](/documents/learn-netsuite/integration-flows/cycle-count.md).
-
-## Orders and Fulfillment
-
-These mappings control how sales-order and fulfillment data created in HotWax is understood by NetSuite.
-
-### Shipping Method
-
-Shipping methods used in HotWax must be mapped to NetSuite shipment method IDs.
-
-- Select the HotWax shipping method.
-- Enter the corresponding NetSuite shipment method ID.
-- Save the mapping.
-
-For more detail, see [Shipping Methods](../../synchronization-flows/integration-mappings/shipping-methods.md).
-
-### Payment Method
-
-Payment methods must be mapped before order sync so NetSuite receives a valid payment method value.
-
-- Select the HotWax payment method.
-- Enter the corresponding NetSuite payment method ID.
-- Save the mapping.
-
-Unmapped payment methods can cause order sync failures.
-
-For more detail, see [Payment Methods](../../synchronization-flows/integration-mappings/payment-methods.md).
-
-### Price Levels
-
-Price level configuration determines what pricing context HotWax sends to NetSuite when orders are created.
-
-Available options generally include:
-
-- **Custom**: Sends the exact order price received from the sales channel.
-- **Base Price**: Uses NetSuite's base item price.
-
-To configure:
-
-- Locate the price levels section.
-- Select the NetSuite price level ID, or choose `Custom`.
-- Save the setting.
-
-For more detail, see [Price Levels](../../synchronization-flows/integration-mappings/price-levels.md).
-
-### Discount Mapping
-
-Order-level and item-level discounts in HotWax should be mapped to the corresponding NetSuite item IDs used for discount posting.
-
-- Identify the discount type used in HotWax.
-- Enter the corresponding NetSuite item ID.
-- Save the mapping.
-
-This prevents discrepancies when orders are created in NetSuite with discounts applied.
-
-### Department
-
-Department mapping is used when the retailer wants facility-level activity attributed to the correct NetSuite department.
-
-- Select the relevant facility.
-- Enter the NetSuite department ID.
-- Save the mapping.
-
-### Sales Channel
-
-Sales channel mapping identifies where an order originated, such as eCommerce or POS.
-
-- Select the HotWax sales channel.
-- Enter the corresponding NetSuite sales channel ID.
-- Save the mapping.
-
-This helps NetSuite classify orders correctly for reporting and downstream workflows.
-
-## Recommended implementation order
-
-To reduce sync failures during setup, configure these settings in this order:
-
-1. Product store to subsidiary mapping
-2. Shipping method mapping
-3. Payment method mapping
-4. Price level selection
-5. Discount mapping
-6. Department mapping
-7. Sales channel mapping
-8. Inventory variance mapping
-
-## Related setup
-
-These settings work together with other NetSuite deployment prerequisites:
-
-- [SFTP Locations](./sftp-locations.md)
-- [Shipping Methods](./shipping-methods.md)
-- [Payment Methods](./payment-methods.md)
-- [Price Level](./price-level.md)
-- [Configure NetSuite Setting](../../../system-admin/administration/company/configure-netsuite-setting.md)
+Those are configured from the **NetSuite** page in the Company App. For that setup, see [Configure NetSuite Setting](/documents/system-admin/administration/company/configure-netsuite-setting.md).

--- a/documents/learn-netsuite/netsuite-deployment/prerequisite-syncs/productstore-settings.md
+++ b/documents/learn-netsuite/netsuite-deployment/prerequisite-syncs/productstore-settings.md
@@ -1,13 +1,144 @@
 ---
-description: Optimize your HotWax integration by configuring Product Store settings
+description: Configure product-store level NetSuite settings required for order, inventory, and fulfillment syncs.
 ---
 
 # Product Store Settings
 
-In order to make sure all flows run as expected, some configurations need to be made in the Product Store settings in HotWax.
+When deploying the HotWax and NetSuite integration, some settings must be configured at the product-store level so data exported from HotWax can be created correctly in NetSuite. These settings are available from the **NetSuite** page in the Company App and are used to control how orders, inventory adjustments, and fulfillment data are mapped between the two systems.
 
-**Auto Approve**
+Use this page during implementation to verify the product store is connected to the correct NetSuite context before you start syncing live data.
 
-HotWax has an Auto Approve flow out of the box. If you have a custom auto approval workflow in NetSuite make sure to turn off this native auto approve workflow in Product Store Settings.
+## Where to configure these settings
 
-{% hint style="warning" %} Auto Aprrove will supersede and approval workflows, it is recommended to keep this off at all times {% endhint %}
+1. Open the **Company App**.
+2. Go to the **NetSuite** page.
+3. Select the product store you want to configure.
+4. Update the settings in the relevant sections described below.
+
+For a UI walkthrough of the NetSuite page, see [Configure NetSuite Setting](/documents/system-admin/administration/company/configure-netsuite-setting.md).
+
+## Product Store
+
+Each HotWax product store must be linked to the NetSuite subsidiary it belongs to.
+
+### NetSuite Subsidiary ID
+
+This mapping tells HotWax which NetSuite subsidiary context to use for the selected product store.
+
+- Select the product store.
+- Enter the corresponding NetSuite subsidiary ID.
+- Save the mapping.
+
+If one HotWax product store needs to work with multiple subsidiaries, configure all required subsidiary IDs for that store from the NetSuite page.
+
+## Product and Inventory
+
+These settings control how inventory-related data is posted to NetSuite.
+
+### Inventory Variance
+
+Inventory variance mappings define how HotWax sends approved inventory adjustments to NetSuite.
+
+Configure the following for each variance reason that should sync:
+
+- Inventory variance reason
+- NetSuite inventory adjustment reason ID
+- NetSuite facility ID, if that variance should post against a specific location
+
+If a retailer uses transfer-style handling for some variance reasons, the facility mapping can be used so the transaction is processed in the correct NetSuite context.
+
+To understand how inventory variance sync works end to end, see [Cycle Count](/documents/learn-netsuite/integration-flows/cycle-count.md).
+
+## Orders and Fulfillment
+
+These mappings control how sales-order and fulfillment data created in HotWax is understood by NetSuite.
+
+### Shipping Method
+
+Shipping methods used in HotWax must be mapped to NetSuite shipment method IDs.
+
+- Select the HotWax shipping method.
+- Enter the corresponding NetSuite shipment method ID.
+- Save the mapping.
+
+For more detail, see [Shipping Methods](/documents/learn-netsuite/synchronization-flows/integration-mappings/shipping-methods.md).
+
+### Payment Method
+
+Payment methods must be mapped before order sync so NetSuite receives a valid payment method value.
+
+- Select the HotWax payment method.
+- Enter the corresponding NetSuite payment method ID.
+- Save the mapping.
+
+Unmapped payment methods can cause order sync failures.
+
+For more detail, see [Payment Methods](/documents/learn-netsuite/synchronization-flows/integration-mappings/payment-methods.md).
+
+### Price Levels
+
+Price level configuration determines what pricing context HotWax sends to NetSuite when orders are created.
+
+Available options generally include:
+
+- **Custom**: Sends the exact order price received from the sales channel.
+- **Base Price**: Uses NetSuite's base item price.
+
+To configure:
+
+- Locate the price levels section.
+- Select the NetSuite price level ID, or choose `Custom`.
+- Save the setting.
+
+For more detail, see [Price Levels](/documents/learn-netsuite/synchronization-flows/integration-mappings/price-levels.md).
+
+### Discount Mapping
+
+Order-level and item-level discounts in HotWax should be mapped to the corresponding NetSuite item IDs used for discount posting.
+
+- Identify the discount type used in HotWax.
+- Enter the corresponding NetSuite item ID.
+- Save the mapping.
+
+This prevents discrepancies when orders are created in NetSuite with discounts applied.
+
+### Department
+
+Department mapping is used when the retailer wants facility-level activity attributed to the correct NetSuite department.
+
+- Select the relevant facility.
+- Enter the NetSuite department ID.
+- Save the mapping.
+
+### Sales Channel
+
+Sales channel mapping identifies where an order originated, such as eCommerce or POS.
+
+- Select the HotWax sales channel.
+- Enter the corresponding NetSuite sales channel ID.
+- Save the mapping.
+
+This helps NetSuite classify orders correctly for reporting and downstream workflows.
+
+## Recommended implementation order
+
+To reduce sync failures during setup, configure these settings in this order:
+
+1. Product store to subsidiary mapping
+2. Shipping method mapping
+3. Payment method mapping
+4. Price level selection
+5. Discount mapping
+6. Department mapping
+7. Sales channel mapping
+8. Inventory variance mapping
+
+## Related setup
+
+These settings work together with other NetSuite deployment prerequisites:
+
+- [SFTP Locations](/documents/learn-netsuite/netsuite-deployment/prerequisite-syncs/sftp-locations.md)
+- [Shipping Methods](/documents/learn-netsuite/netsuite-deployment/prerequisite-syncs/shipping-methods.md)
+- [Payment Methods](/documents/learn-netsuite/netsuite-deployment/prerequisite-syncs/payment-methods.md)
+- [Price Level](/documents/learn-netsuite/netsuite-deployment/prerequisite-syncs/price-level.md)
+- [Configure NetSuite Setting](/documents/system-admin/administration/company/configure-netsuite-setting.md)


### PR DESCRIPTION
## Summary\n- replace the Learn NetSuite product-store settings stub with a complete setup page\n- document subsidiary, inventory variance, and order/fulfillment mappings from the NetSuite page\n- link to the related NetSuite mapping and deployment docs\n\n## Issues addressed\n- closes #1311