### PR TITLE
[Store Operations] Update Settings Page document for BOPIS and Fulfillment App

### DIFF
--- a/documents/store-operations/bopis/settings-page.md
+++ b/documents/store-operations/bopis/settings-page.md
@@ -8,13 +8,21 @@ description: >-
 
 Settings for the BOPIS app can be accessed by clicking on the `Settings` button on the bottom tab of the app. It displays a list of all the settings that can be configured to streamline processes and optimize BOPIS efficiency.
 
-#### Facility
+Settings are categorized as either **store-specific** (apply to all users at a facility), **facility-specific** (apply to the selected facility), or **user-specific** (apply only to the individual user).
+
+## OMS
+
+### Facility
+
+`Facility-specific`
 
 Users can use this setting to select the facility they want to operate from. Orders, inventory and other configuration data will be specific to the facility that the users select.
 
 <figure><img src="../.gitbook/assets/select-facility-setting.png" alt="" width="375"><figcaption></figcaption></figure>
 
-#### Order Edit Permissions
+### Order Edit Permissions
+
+`Store-specific`
 
 If an order is rejected by the store, the customer receives an email notifying them of the rejection and outlining the alternate fulfillment options that are available. Users can use toggle buttons to conveniently enable or disable permissions for various aspects of the orders that customers are allowed to edit when updating their orders on Re-route Fulfillment.
 
@@ -22,48 +30,81 @@ If an order is rejected by the store, the customer receives an email notifying t
 * **Delivery Address:** Enable or disable the permission for customers to edit the delivery address for their orders.
 * **Pickup Location:** Enable or disable the permission for customers to edit the pickup location for their orders.
 * **Order Item Split:** Enable or disable the permission for customers to split order items for their orders.
-* **Cancel Order Before Fulfillment:** Enable or disable the permission for customers to cancel their order before it’s fulfilled.
+* **Cancel Order Before Fulfillment:** Enable or disable the permission for customers to cancel their order before it's fulfilled.
 * **Shipment Method:** Allow the customers to edit the shipment method for their orders using a dropdown menu with available options.
 
 <figure><img src="../.gitbook/assets/order-edit-permissions-setting.png" alt="" width="375"><figcaption></figcaption></figure>
 
-#### Partial Order Rejection
+### Partial Order Rejection
+
+`Store-specific`
 
 Store managers can use this setting to control whether a BOPIS order can be partially rejected in case there is insufficient inventory of specific items at the store.
 
-#### Product Identifier
+## App
+
+### Product Identifier
+
+`User-specific`
 
 Users can choose primary and secondary product identifiers (such as product ID, product title, SKU, etc.) to view products with preferred identifiers in the app.
 
 <figure><img src="../.gitbook/assets/product-identifier-setting.png" alt="" width="375"><figcaption></figcaption></figure>
 
-#### Timezone
+### Timezone
+
+`User-specific`
 
 This option allows users to select an appropriate timezone to ensure consistency and optimize operations according to local time.
 
-#### Language
+### Language
+
+`User-specific`
 
 This option allows users to select a preferred display language for the app.
 
-#### Shipping Orders
+### Shipping Orders
+
+`Store-specific`
 
 For stores managing both `BOPIS` and `Ship from Store` orders, switching between apps can be challenging. To optimize this process, the `Show Shipping Orders` feature can be enabled. This will allow users to view and fulfill regular orders brokered to their store by the OMS directly within the BOPIS app. Users can easily control this setting using the toggle button to enable or disable it as needed.
 
 <figure><img src="../.gitbook/assets/show-shipping-orders-setting.png" alt="" width="375"><figcaption></figcaption></figure>
 
-#### Packing Slip
+### Packing Slip
 
-Packing slips help customers reconcile their orders against the delivered items. Store managers can use the Generate Packing Slip toggle to control whether or not packing slips are generated for orders.
+`Store-specific`
+
+Packing slips help customers reconcile their orders against the delivered items. Store managers can use the `Generate Packing Slips` toggle to control whether or not packing slips are generated for orders.
 
 <figure><img src="../.gitbook/assets/packing-slip-setting.png" alt="" width="375"><figcaption></figcaption></figure>
 
-#### Track Pickers
+### Track Pickers
 
-Store managers can assign store pickup orders to store associates and track associates who picked orders, by entering their picker IDs when packing an order. They can use the `Track Pickers` toggle to enable tracking. This is essential to manage picker commission.
+`Store-specific`
+
+Store managers can assign store pickup orders to store associates and track associates who picked orders, by entering their picker IDs when packing an order. They can use the `Track Pickers` card to manage picker tracking and picklist printing. This is essential to manage picker commission.
+
+* **Enable Tracking:** Turn on picker tracking to require store associates to enter their picker ID when packing an order.
+* **Print Picklists:** Enable automatic printing of picklists when packing orders to help store associates identify and gather the items to be fulfilled.
 
 <figure><img src="../.gitbook/assets/track-pickers-setting.png" alt="" width="375"><figcaption></figcaption></figure>
 
-#### Notification Preferences
+### Request Transfer
+
+`Store-specific`
+
+This setting allows store associates to request an item from another store when it is not available in their current stock. When enabled, a `Request Transfer` option becomes available on order detail pages so associates can initiate inter-store transfer requests directly from the app.
+
+### Proof of Delivery
+
+`Store-specific`
+
+This setting allows store associates to capture and verify proof of delivery when handing over a pickup order to a customer. When enabled, associates are prompted to confirm handover of the order, providing a verifiable record of the delivery.
+
+### Notification Preferences
+
+`User-specific`
 
 Users can select the notifications they want to receive in the BOPIS app.
 
@@ -72,4 +113,3 @@ Users can select the notifications they want to receive in the BOPIS app.
 * **Ready for pickup order notification:** Enable or disable notifications for orders that are ready to be picked up by customers.
 
 <figure><img src="../.gitbook/assets/notification-preferences-setting.png" alt="" width="375"><figcaption></figcaption></figure>
-

--- a/documents/store-operations/bopis/settings-page.md
+++ b/documents/store-operations/bopis/settings-page.md
@@ -55,7 +55,7 @@ Users can choose primary and secondary product identifiers (such as product ID, 
 
 `User-specific`
 
-This option allows users to select an appropriate timezone to ensure consistency and optimize operations according to local time.
+This option allows users to select an appropriate timezone to maintain consistency and optimize operations according to local time.
 
 ### Language
 
@@ -83,7 +83,7 @@ Packing slips help customers reconcile their orders against the delivered items.
 
 `Store-specific`
 
-Store managers can assign store pickup orders to store associates and track associates who picked orders, by entering their picker IDs when packing an order. They can use the `Track Pickers` card to manage picker tracking and picklist printing. This is essential to manage picker commission.
+Store managers can assign store pickup orders to store associates and track associates who picked orders, by entering their picker IDs when packing an order. They can use the `Track Pickers` card to manage picker tracking and picklist printing. This is important for managing picker commission.
 
 * **Enable Tracking:** Turn on picker tracking to require store associates to enter their picker ID when packing an order.
 * **Print Picklists:** Enable automatic printing of picklists when packing orders to help store associates identify and gather the items to be fulfilled.

--- a/documents/store-operations/bopis/settings-page.md
+++ b/documents/store-operations/bopis/settings-page.md
@@ -8,7 +8,7 @@ description: >-
 
 Settings for the BOPIS app can be accessed by clicking on the `Settings` button on the bottom tab of the app. It displays a list of all the settings that can be configured to streamline processes and optimize BOPIS efficiency.
 
-Settings are categorized as either **store-specific** (apply to all users at a facility), **facility-specific** (apply to the selected facility), or **user-specific** (apply only to the individual user).
+Settings are categorized as either **product store wide** (apply across the entire company for all users), **facility-specific** (apply to the selected facility), or **user-specific** (apply only to the individual user).
 
 ## OMS
 
@@ -22,7 +22,7 @@ Users can use this setting to select the facility they want to operate from. Ord
 
 ### Order Edit Permissions
 
-`Store-specific`
+`Product store wide`
 
 If an order is rejected by the store, the customer receives an email notifying them of the rejection and outlining the alternate fulfillment options that are available. Users can use toggle buttons to conveniently enable or disable permissions for various aspects of the orders that customers are allowed to edit when updating their orders on Re-route Fulfillment.
 
@@ -37,7 +37,7 @@ If an order is rejected by the store, the customer receives an email notifying t
 
 ### Partial Order Rejection
 
-`Store-specific`
+`Product store wide`
 
 Store managers can use this setting to control whether a BOPIS order can be partially rejected in case there is insufficient inventory of specific items at the store.
 
@@ -65,7 +65,7 @@ This option allows users to select a preferred display language for the app.
 
 ### Shipping Orders
 
-`Store-specific`
+`Product store wide`
 
 For stores managing both `BOPIS` and `Ship from Store` orders, switching between apps can be challenging. To optimize this process, the `Show Shipping Orders` feature can be enabled. This will allow users to view and fulfill regular orders brokered to their store by the OMS directly within the BOPIS app. Users can easily control this setting using the toggle button to enable or disable it as needed.
 
@@ -73,7 +73,7 @@ For stores managing both `BOPIS` and `Ship from Store` orders, switching between
 
 ### Packing Slip
 
-`Store-specific`
+`Product store wide`
 
 Packing slips help customers reconcile their orders against the delivered items. Store managers can use the `Generate Packing Slips` toggle to control whether or not packing slips are generated for orders.
 
@@ -81,7 +81,7 @@ Packing slips help customers reconcile their orders against the delivered items.
 
 ### Track Pickers
 
-`Store-specific`
+`Product store wide`
 
 Store managers can assign store pickup orders to store associates and track associates who picked orders, by entering their picker IDs when packing an order. They can use the `Track Pickers` card to manage picker tracking and picklist printing. This is important for managing picker commission.
 
@@ -92,13 +92,13 @@ Store managers can assign store pickup orders to store associates and track asso
 
 ### Request Transfer
 
-`Store-specific`
+`Product store wide`
 
 This setting allows store associates to request an item from another store when it is not available in their current stock. When enabled, a `Request Transfer` option becomes available on order detail pages so associates can initiate inter-store transfer requests directly from the app.
 
 ### Proof of Delivery
 
-`Store-specific`
+`Product store wide`
 
 This setting allows store associates to capture and verify proof of delivery when handing over a pickup order to a customer. When enabled, associates are prompted to confirm handover of the order, providing a verifiable record of the delivery.
 

--- a/documents/store-operations/fulfillment/fulfillment-setting-page.md
+++ b/documents/store-operations/fulfillment/fulfillment-setting-page.md
@@ -93,7 +93,7 @@ This setting controls whether store associates receive notifications for orders 
 
 ### Force Scan
 
-`Store-specific`
+`Product store wide`
 
 This card contains two related settings for controlling barcode scanning behavior during order fulfillment:
 
@@ -102,18 +102,18 @@ This card contains two related settings for controlling barcode scanning behavio
 
 ### Allow Partial Rejections
 
-`Store-specific`
+`Product store wide`
 
 When [Partial Rejection is enabled](/documents/store-operations/fulfillment/rejection.md), individual items get rejected from a facility without impacting the rest of the order.
 
 ### Collateral Rejections
 
-`Store-specific`
+`Product store wide`
 
 [Collateral Rejection](rejection.md) helps manage situations where the product in a rejected order item is part of multiple pending orders at a facility. When enabled, rejecting an item in one order automatically rejects the same product in all other pending orders.
 
 ### Affect QOH on Rejection
 
-`Store-specific`
+`Product store wide`
 
 [The Affect QOH on Rejection](/documents/store-operations/fulfillment/rejection.md) toggle provides control over inventory adjustments during order rejections.

--- a/documents/store-operations/fulfillment/fulfillment-setting-page.md
+++ b/documents/store-operations/fulfillment/fulfillment-setting-page.md
@@ -59,7 +59,7 @@ This setting allows selection of a primary and secondary product identifier, suc
 
 `User-specific`
 
-This setting allows selecting an appropriate timezone to ensure consistency and optimize operations according to local time.
+This setting allows selecting an appropriate timezone to maintain consistency and optimize operations according to local time.
 
 <figure><img src="../.gitbook/assets/fulfillment-timezone-setting.png" alt="" width="375"><figcaption><p>Select timezone</p></figcaption></figure>
 

--- a/documents/store-operations/fulfillment/fulfillment-setting-page.md
+++ b/documents/store-operations/fulfillment/fulfillment-setting-page.md
@@ -11,13 +11,13 @@ description: >-
 
 </div>
 
-Settings are categorized as either **store-specific** (apply to all users at a facility), **facility-specific** (apply to the selected facility), or **user-specific** (apply only to the individual user).
+Settings are categorized as either **product store wide** (apply across the entire company for all users), **facility-specific** (apply to the selected facility), or **user-specific** (apply only to the individual user).
 
 ## OMS
 
 ### Product Store
 
-`Store-specific`
+`User-specific`
 
 A Product Store represents a brand or a set of products. If your OMS is connected to multiple eCommerce brands selling different product collections, you can have separate Product Stores in HotWax Commerce.
 
@@ -25,7 +25,7 @@ A Product Store represents a brand or a set of products. If your OMS is connecte
 
 ### Facility
 
-`Facility-specific`
+`User-specific`
 
 The Fulfillment App allows authorized users to select a facility to operate from, determining the visibility of orders, inventory, and other configuration data.
 

--- a/documents/store-operations/fulfillment/fulfillment-setting-page.md
+++ b/documents/store-operations/fulfillment/fulfillment-setting-page.md
@@ -11,9 +11,13 @@ description: >-
 
 </div>
 
+Settings are categorized as either **store-specific** (apply to all users at a facility), **facility-specific** (apply to the selected facility), or **user-specific** (apply only to the individual user).
+
 ## OMS
 
 ### Product Store
+
+`Store-specific`
 
 A Product Store represents a brand or a set of products. If your OMS is connected to multiple eCommerce brands selling different product collections, you can have separate Product Stores in HotWax Commerce.
 
@@ -21,11 +25,15 @@ A Product Store represents a brand or a set of products. If your OMS is connecte
 
 ### Facility
 
+`Facility-specific`
+
 The Fulfillment App allows authorized users to select a facility to operate from, determining the visibility of orders, inventory, and other configuration data.
 
 <figure><img src="../.gitbook/assets/facility-selection-modal.png" alt="" width="375"><figcaption><p>Select Facility</p></figcaption></figure>
 
 ### Online Order Fulfillment
+
+`Facility-specific`
 
 Adjust the order fulfillment capacity for your facility. If you set the fulfillment capacity to 0, new orders will not be allocated to this facility. Leave this field empty if the fulfillment capacity of this facility is unlimited. Setting fulfillment capacity to No capacity disables new orders from being allocated to this facility. Select Unlimited Capacity if this facility's fulfillment capacity is unrestricted. You can also select a custom option to set the capacity limit.
 
@@ -33,11 +41,15 @@ Adjust the order fulfillment capacity for your facility. If you set the fulfillm
 
 ### Sell Inventory Online
 
+`Facility-specific`
+
 Determine whether the inventory of the store should be accessible for online sales or not. This setting allows you to specify whether the products available in your physical store should also be available for purchase through online channels or not. If enabled, customers browsing your online store will be able to see and purchase items from your inventory. If disabled, the products will not be listed for online sale, restricting purchases to in-store transactions only.
 
 ## App
 
 ### Product Identifier
+
+`User-specific`
 
 This setting allows selection of a primary and secondary product identifier, such as product ID or SKU, to control how products are displayed in the app.
 
@@ -45,11 +57,15 @@ This setting allows selection of a primary and secondary product identifier, suc
 
 ### Timezone
 
-This setting allows selecting an appropriate timezone to ensure consistency and optimize operations according to local time. 
+`User-specific`
+
+This setting allows selecting an appropriate timezone to ensure consistency and optimize operations according to local time.
 
 <figure><img src="../.gitbook/assets/fulfillment-timezone-setting.png" alt="" width="375"><figcaption><p>Select timezone</p></figcaption></figure>
 
 ### Language
+
+`User-specific`
 
 Choose the preferred display language. This setting controls the language used throughout the interface.
 
@@ -57,30 +73,47 @@ Choose the preferred display language. This setting controls the language used t
 
 ### Additional Documents
 
-#### Shipping Label and Packing Slip Settings
+`User-specific`
 
 These settings control whether shipping labels and packing slips are printed along with each shipment by default.
 
-##### Generate Shipping Label  
-A shipping label is used by the delivery carrier to send the package to the customer’s address. This setting controls whether shipping labels should be printed for the selected location.  
-	
-##### Generate Packing Slip  
+##### Generate Shipping Label
+A shipping label is used by the delivery carrier to send the package to the customer's address. This setting controls whether shipping labels should be printed for the selected location.
+
+##### Generate Packing Slip
 A packing slip shows the list of items in an order and helps match delivered products with what was ordered. This setting allows deciding whether to print packing slips for shipments or not.
 
 <figure><img src="../.gitbook/assets/additional-documents-setting.png" alt="" width="375"><figcaption><p>Additional Documents</p></figcaption></figure>
 
 ### Notification Preference
+
+`User-specific`
+
 This setting controls whether store associates receive notifications for orders awaiting fulfillment.
 
 ### Force Scan
-This setting enables store associates to select the barcode identifier used for scanning and specify whether scanning is required
+
+`Store-specific`
+
+This card contains two related settings for controlling barcode scanning behavior during order fulfillment:
+
+* **Require Scan:** When enabled, store associates must scan the barcode of each product to increment the shipped quantity. This prevents manual entry and helps reduce packing errors.
+* **Barcode Identifier:** Select the product identifier (such as SKU, UPC, or internal name) that will be used when scanning barcodes. If the selected identifier is not found on a product, the scan will fall back to using the product's internal name.
 
 ### Allow Partial Rejections
+
+`Store-specific`
+
 When [Partial Rejection is enabled](/documents/store-operations/fulfillment/rejection.md), individual items get rejected from a facility without impacting the rest of the order.
 
-### Allow Collateral Rejection
+### Collateral Rejections
+
+`Store-specific`
+
 [Collateral Rejection](rejection.md) helps manage situations where the product in a rejected order item is part of multiple pending orders at a facility. When enabled, rejecting an item in one order automatically rejects the same product in all other pending orders.
 
 ### Affect QOH on Rejection
-[The Affect QOH on Rejection](/documents/store-operations/fulfillment/rejection.md) toggle provides control over inventory adjustments during order rejections.
 
+`Store-specific`
+
+[The Affect QOH on Rejection](/documents/store-operations/fulfillment/rejection.md) toggle provides control over inventory adjustments during order rejections.


### PR DESCRIPTION
## Summary

Closes #982

Updates the Settings page documentation for both the BOPIS and Fulfillment apps based on the current source code (`Settings.vue`).

## Changes

### BOPIS App (`settings-page.md`)
- Added missing **Request Transfer** setting — allows store associates to request items from another store when inventory is insufficient
- Added missing **Proof of Delivery** setting — allows store associates to capture handover confirmation for pickup orders
- Added missing **Print Picklists** toggle within the Track Pickers section
- Added user/store/facility specificity labels to all settings
- Restructured settings under **OMS** and **App** sections to match the actual app layout

### Fulfillment App (`fulfillment-setting-page.md`)
- Clarified the **Force Scan** card to document the **Barcode Identifier** dropdown alongside the Require Scan toggle
- Added user/store/facility specificity labels to all settings

## Setting Specificity Reference

| App | Setting | Scope |
|-----|---------|-------|
| BOPIS | Facility | Facility-specific |
| BOPIS | Order Edit Permissions | Store-specific |
| BOPIS | Partial Order Rejection | Store-specific |
| BOPIS | Product Identifier | User-specific |
| BOPIS | Timezone / Language | User-specific |
| BOPIS | Shipping Orders / Packing Slip / Track Pickers / Request Transfer / Proof of Delivery | Store-specific |
| BOPIS | Notification Preferences | User-specific |
| Fulfillment | Product Store | Store-specific |
| Fulfillment | Facility / Online Order Fulfillment / Sell Inventory Online | Facility-specific |
| Fulfillment | Product Identifier / Timezone / Language / Additional Documents / Notification Preference | User-specific |
| Fulfillment | Force Scan / Partial Rejections / Collateral Rejections / Affect QOH | Store-specific |