### PR TITLE
Add missing FF_DOWNLOAD_PICKLIST documentation

### DIFF
--- a/documents/system-admin/product-store/add-more-product-stores.md
+++ b/documents/system-admin/product-store/add-more-product-stores.md
@@ -81,7 +81,7 @@ Adjust the additional Product Store settings according to your specific requirem
 | APPR_WO_PMNT_CHK        | Y                                             | Allows approval without payment check.                                          | Y → Order approved without payment received.                                 |
 | AFFECT_QOH_ON_REJ       | TRUE                                          | Adjusts QOH when an order is rejected.                                          | TRUE → QOH updated on rejection.                                             |
 | INV_CNT_VIEW_QOH        | FALSE                                         | Shows QOH in Inventory Count app if TRUE.                                       | FALSE → Hide QOH, TRUE → Show QOH.                                           |
-| FF_DOWNLOAD_PICKLIST    | FALSE                                         | Controls picklist download format (CSV vs PDF).                                 | Set to TRUE to download picklists as CSV for easier filtering.               |
+| `FF_DOWNLOAD_PICKLIST` | FALSE | Determines the download format for picklists (CSV or PDF). | FALSE → Open as PDF, TRUE → Download as CSV. |
 
 
 3. **Create Product Catalog-** A product catalog for the newly created product store needs to be created which defines which product will be sold through the created product store.

--- a/documents/system-admin/product-store/add-more-product-stores.md
+++ b/documents/system-admin/product-store/add-more-product-stores.md
@@ -81,6 +81,7 @@ Adjust the additional Product Store settings according to your specific requirem
 | APPR_WO_PMNT_CHK        | Y                                             | Allows approval without payment check.                                          | Y → Order approved without payment received.                                 |
 | AFFECT_QOH_ON_REJ       | TRUE                                          | Adjusts QOH when an order is rejected.                                          | TRUE → QOH updated on rejection.                                             |
 | INV_CNT_VIEW_QOH        | FALSE                                         | Shows QOH in Inventory Count app if TRUE.                                       | FALSE → Hide QOH, TRUE → Show QOH.                                           |
+| FF_DOWNLOAD_PICKLIST    | FALSE                                         | Controls picklist download format (CSV vs PDF).                                 | Set to TRUE to download picklists as CSV for easier filtering.               |
 
 
 3. **Create Product Catalog-** A product catalog for the newly created product store needs to be created which defines which product will be sold through the created product store.

--- a/documents/system-admin/product-store/product-store-settings.md
+++ b/documents/system-admin/product-store/product-store-settings.md
@@ -29,6 +29,7 @@ These settings govern inventory allocation, fulfillment behavior, and app-level 
 | `DISABLE_UNPACK` | Disable unpack button | Controls visibility of the "Unpack" button in fulfillment workflows. | Restricts users from reversing packing operations. |
 | `PCKGING_BOX_ALGO` | Packaging box algo | Algorithm used to suggest the best box size for an order. | Optimizes packaging efficiency and shipping costs. |
 | `RATE_SHOPPING` | Rate shopping | Enables or disables the rate shopping feature in the OMS. | Allows comparing shipping rates across multiple carriers. |
+| `FF_DOWNLOAD_PICKLIST` | Download picklist as CSV | Determines whether the picklist is downloaded as a CSV file or opened as a PDF. | Provides flexibility for store associates to filter and sort picklist data in external tools. |
 
 ## Store pickup (BOPIS) settings
 


### PR DESCRIPTION
This PR adds the missing documentation for the `FF_DOWNLOAD_PICKLIST` setting in the Product Store Settings and "Add More Product Stores" guides.

- Added `FF_DOWNLOAD_PICKLIST` to `documents/system-admin/product-store/product-store-settings.md`
- Added `FF_DOWNLOAD_PICKLIST` to `documents/system-admin/product-store/add-more-product-stores.md`

Closes #1302