### PR TITLE
docs: update product store creation to reflect new UI and automated setup

### DIFF
--- a/documents/system-admin/product-store/add-more-product-stores.md
+++ b/documents/system-admin/product-store/add-more-product-stores.md
@@ -14,7 +14,7 @@ When retailers deploy HotWax Commerce, a default product store is automatically 
 However, if a retailer has multiple brands, additional product stores need to be created. Follow these steps to create a new product store in HotWax Commerce,
 
 1. **Create Product Store Groups-** In HotWax Commerce, retailers can define product store groups linked to the company. When creating a product store, it is automatically added to the group of the default product store.
-2. **Create Product Store-** You can create a product store through the `Create Product Store` page. Navigate to `Settings` > `Product Stores` from the hamburger menu and click on the `Create` button. This action will open a form for creating a new product store. 
+2. **Create Product Store:** You can create a product store through the `Create Product Store` page. Navigate to `Settings` > `Product Stores` from the hamburger menu and click on the `Create` button. This action will open a form for creating a new product store. 
 
 When a product store is created, HotWax Commerce automatically sets up the following:
 * **Product Catalog:** A catalog named `${productStoreId} Catalog` is created and associated with the store.
@@ -30,7 +30,7 @@ Retailers should fill out the following attributes in the creation form:
 | Company Name        | The name of the company owning the store.                                   | `NotNaked`              |
 | Pay To Party        | The internal organization party responsible for payments.                   | `NotNaked_COMPANY`      |
 | Product Store Group | The group to which this store belongs (e.g., a specific brand group).       | `NotNaked_STORE_GROUP`  |
-| Inventory Facility  | The primary facility where inventory for this store is managed.              | `Main_Warehouse`        |
+| Inventory Facility  | The primary facility where inventory for this store is managed. | `Main_Warehouse`        |
 | Currency            | The default currency used for transactions in this store.                   | `USD`                   |
 
 {% hint style="info" %}
@@ -89,7 +89,7 @@ Adjust the additional Product Store settings according to your specific requirem
 | INV_CNT_VIEW_QOH        | FALSE                                         | Shows QOH in Inventory Count app if TRUE.                                       | FALSE → Hide QOH, TRUE → Show QOH.                                           |
 | FF_DOWNLOAD_PICKLIST    | FALSE                                         | Controls picklist download format (CSV vs PDF).                                 | Set to TRUE to download picklists as CSV for easier filtering.               |
 
-3. **Verify Automated Setup-** After creating the product store, you can verify that the catalog and categories were created correctly:
+3. **Verify Automated Setup:** After creating the product store, you can verify that the catalog and categories were created correctly:
    * Navigate to `Settings` > `Product Stores`.
    * Find your newly created store and click on it to open the `View Product Store` page.
    * Verify that the `Product Catalog` section shows the correctly linked catalog.

--- a/documents/system-admin/product-store/add-more-product-stores.md
+++ b/documents/system-admin/product-store/add-more-product-stores.md
@@ -14,28 +14,34 @@ When retailers deploy HotWax Commerce, a default product store is automatically 
 However, if a retailer has multiple brands, additional product stores need to be created. Follow these steps to create a new product store in HotWax Commerce,
 
 1. **Create Product Store Groups-** In HotWax Commerce, retailers can define product store groups linked to the company. When creating a product store, it is automatically added to the group of the default product store.
-2. **Create Product Store-** You can create a product store through the `Create Store` page. Simply click on `Create Store` from the hamburger menu. This action will open a form for creating a new product store. Retailers should fill out specific attributes with defined values. For instance, consider the details needed for a product store named WasatchSki. Adjust the following attributes according to your retail brand.
+2. **Create Product Store-** You can create a product store through the `Create Product Store` page. Navigate to `Settings` > `Product Stores` from the hamburger menu and click on the `Create` button. This action will open a form for creating a new product store. 
 
-| Attribute           | Value                  | Description              |
-| ------------------- | ---------------------- | ------------------------ |
-| companyName         | NotNaked               | The name of the company. |
-| inventoryFacilityId | _NA_                   | Inventory facility ID.   |
-| payToPartyId        | NotNaked\_COMPANY      | Party ID for payment.    |
-| primaryStoreGroupId | NotNaked\_STORE\_GROUP | Primary store group ID.  |
-| productStoreId      | WS\_STORE              | Product store ID.        |
-| storeName           | WasatchSki             | The name of the store.   |
-| subtitle            | WS                     | Subtitle for the store.  |
-| title               | WasatchSki             | Title of the store.      |
+When a product store is created, HotWax Commerce automatically sets up the following:
+* **Product Catalog:** A catalog named `${productStoreId} Catalog` is created and associated with the store.
+* **Product Categories:** Essential categories for browsing (`_BR`), search (`_CS`), purchase allow (`_PA`), view allow (`_VA`), preorder (`_PC`), backorder (`_BC`), and preorder not allow (`_PC_NTAL`) are automatically created and associated with the catalog.
+* **WebSite:** A website record (`${productStoreId}_WEBSTORE`) is created for the store.
+
+Retailers should fill out the following attributes in the creation form:
+
+| Attribute           | Description                                                                 | Example                 |
+| ------------------- | --------------------------------------------------------------------------- | ----------------------- |
+| Product Store ID    | A unique identifier for the product store.                                  | `WS_STORE`              |
+| Store Name          | The name of the retail brand or store.                                      | `WasatchSki`            |
+| Company Name        | The name of the company owning the store.                                   | `NotNaked`              |
+| Pay To Party        | The internal organization party responsible for payments.                   | `NotNaked_COMPANY`      |
+| Product Store Group | The group to which this store belongs (e.g., a specific brand group).       | `NotNaked_STORE_GROUP`  |
+| Inventory Facility  | The primary facility where inventory for this store is managed.              | `Main_Warehouse`        |
+| Currency            | The default currency used for transactions in this store.                   | `USD`                   |
 
 {% hint style="info" %}
-Add company and product store details as per your retail brand
+Add company and product store details as per your retail brand. Many other settings have default values and can be adjusted later from the `View Product Store` page.
 {% endhint %}
 
 {% hint style="danger" %}
-Make sure your product store ID ends with `_store` for accurate product store representation.
+Make sure your product store ID ends with `_STORE` for accurate representation and consistency.
 {% endhint %}
 
-Adjust the additional Product Store settings according to your specific requirements for the following details:
+Adjust the additional Product Store settings according to your specific requirements on the same page or later in the `View Store` section:
 
 | **Attribute**                | **Value**                                     | **Description**                                                                 | **Example**                                                                 |
 |-----------------------------|-----------------------------------------------|---------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
@@ -81,108 +87,13 @@ Adjust the additional Product Store settings according to your specific requirem
 | APPR_WO_PMNT_CHK        | Y                                             | Allows approval without payment check.                                          | Y → Order approved without payment received.                                 |
 | AFFECT_QOH_ON_REJ       | TRUE                                          | Adjusts QOH when an order is rejected.                                          | TRUE → QOH updated on rejection.                                             |
 | INV_CNT_VIEW_QOH        | FALSE                                         | Shows QOH in Inventory Count app if TRUE.                                       | FALSE → Hide QOH, TRUE → Show QOH.                                           |
-| `FF_DOWNLOAD_PICKLIST` | FALSE | Determines the download format for picklists (CSV or PDF). | FALSE → Open as PDF, TRUE → Download as CSV. |
+| FF_DOWNLOAD_PICKLIST    | FALSE                                         | Controls picklist download format (CSV vs PDF).                                 | Set to TRUE to download picklists as CSV for easier filtering.               |
 
-
-3. **Create Product Catalog-** A product catalog for the newly created product store needs to be created which defines which product will be sold through the created product store.
-
-Import the following XML to create the product catalog
-
-<details>
-
-<summary>Create Product Ctalog</summary>
-
-`<ProdCatalog prodCatalogId="WS_CATALOG" catalogName="WasatchSki Catalog" useQuickAdd="Y"/>`\
-\
-Replace "WS\_CATALOG" and "WasatchSki Catalog" with the desired value for the new catalog as per your retail brand.
-
-</details>
-
-4. **Associate product store with product catalog-** After creating a product store and product catalog in HotWax Commerce, the next crucial step is to associate them. This ensures accurate mapping, allowing the correct products to be linked with the designated product store. Utilize the following XML template for creating the association:
-
-<details>
-
-<summary>Associate Product Catalog</summary>
-
-`<ProductStoreCatalog productStoreId="WS_STORE" prodCatalogId="WS_CATALOG" fromDate="2022-07-01 12:00:00.000" sequenceNum="2”/>`\
-\
-Adjust "WS\_STORE" and "WS\_CATALOG" to match the respective product store and catalog IDs.
-
-</details>
-
-5. **Create Product Category-** In HotWax Commerce, effective product management involves creating product categories, especially for handling pre-order and backorder products. The following attributes are essential for accurately defining product categories:
-
-The following fields need to be inserted to create the product category
-
-| Attribute             | Description                                  |
-| --------------------- | -------------------------------------------- |
-| productCategoryId     | Identifier for the product category          |
-| productCategoryTypeId | Type of the product category                 |
-| categoryName          | Name of the product category                 |
-| description           | Brief description of the product category    |
-| longDescription       | Detailed description of the product category |
-
-To create a product category, import an XML file with data similar to the provided sample:
-
-<details>
-
-<summary>Create Product Category</summary>
-
-`<ProductCategory productCategoryId="WS_BROWSE_ROOT" productCategoryTypeId="CATALOG_CATEGORY" categoryName="WS_Browse Root" description="WS Browse Root" longDescription="Demo Catalog Primary Browse Root Category"/>`
-
-`<ProductCategory productCategoryId="WS_CATALOG_SEARCH" productCategoryTypeId="SEARCH_CATEGORY" categoryName="WS Catalog Search" description="Catalog Search" longDescription="Search Products - only products in this category will show up in a search in CATALOG"/>`
-
-`<ProductCategory productCategoryId="WS_PURCHASE_ALLOW" productCategoryTypeId="CATALOG_CATEGORY" categoryName="WS_Purchase Allow" longDescription="Products in this category are enabled for purchasing"/>`
-
-`<ProductCategory productCategoryId="WS_VIEW_ALLOW" productCategoryTypeId="CATALOG_CATEGORY" categoryName="WS_VIEW_ALLOW" description="Products in this category are visible on web site."/>`
-
-`<ProductCategory productCategoryId="WS_PREORDER_CAT" productCategoryTypeId="CATALOG_CATEGORY" categoryName="WS_PREORDER" description="Pre-order Category"/>`
-
-`<ProductCategory productCategoryId="WS_BACKORDER_CAT" productCategoryTypeId="CATALOG_CATEGORY" categoryName="WS_BACKORDER" description="Backorder Category"/>`
-
-`<ProductCategory productCategoryId="WS_PREODR_NT_ALW" productCategoryTypeId="CATALOG_CATEGORY" categoryName="WS Preorder Not Allow Items" description="Preorder Not Allow Items Specific Category."/>`
-
-</details>
-
-Make sure to customize all product category IDs and names, and consider adding a company name prefix or suffix to the IDs. It's crucial not to alter any type IDs as specified in the note above. This process ensures accurate and tailored product categorization within HotWax Commerce.
-
-6. **Product Catalog and Product Category Association-** Associating catalogs and categories within HotWax Commerce is a feature for effective product management. It allows users to link specific product categories to a catalog, ensuring accurate representation and organization of products.
-
-<details>
-
-<summary>Associate Product Category</summary>
-
-`<ProdCatalogCategory prodCatalogId="WS_CATALOG" productCategoryId="WS_BROWSE_ROOT" prodCatalogCategoryTypeId="PCCT_BROWSE_ROOT" fromDate="2022-07-01 12:00:00.000" sequenceNum="1"/>`
-
-`<ProdCatalogCategory prodCatalogId="WS_CATALOG" productCategoryId="WS_PURCHASE_ALLOW" prodCatalogCategoryTypeId="PCCT_PURCH_ALLW" fromDate="2022-07-01 12:00:00.000" sequenceNum="2"/>`
-
-`<ProdCatalogCategory prodCatalogId="WS_CATALOG" productCategoryId="WS_VIEW_ALLOW" prodCatalogCategoryTypeId="PCCT_VIEW_ALLW" fromDate="2022-07-01 12:00:00.000" sequenceNum="3"/>`
-
-`<ProdCatalogCategory prodCatalogId="WS_CATALOG" productCategoryId="WS_CATALOG_SEARCH" prodCatalogCategoryTypeId="PCCT_SEARCH" fromDate="2022-07-01 12:00:00.000" sequenceNum="4"/>`
-
-`<ProdCatalogCategory prodCatalogId="WS_CATALOG" productCategoryId="WS_PREORDER_CAT" prodCatalogCategoryTypeId="PCCT_PREORDR" fromDate="2022-07-01 12:00:00.000" sequenceNum="5"/>`
-
-`<ProdCatalogCategory prodCatalogId="WS_CATALOG" productCategoryId="WS_BACKORDER_CAT" prodCatalogCategoryTypeId="PCCT_BACKORDER" fromDate="2022-07-01 12:00:00.000" sequenceNum="6"/>`
-
-`<ProdCatalogCategory prodCatalogId="WS_CATALOG" productCategoryId="WS_PREODR_NT_ALW" prodCatalogCategoryTypeId="PCCT_PREORDR_NOT" fromDate="2022-07-01 12:00:00.000" sequenceNum="7"/>`
-
-</details>
-
-In this dataset, input the previously created product catalog ID and category IDs. Maintain the existing type IDs without alterations. Set the `from date` in the data either as the project's go-live date or 10 days past. Additionally, verify the sequence numbers in the data for accuracy.
-
-7. **Add Default data-** To ensure the seamless establishment of the product store, it's essential to integrate default data via XML import. However, moving forward, this default data will be omitted to streamline the product store creation process.
-
-<details>
-
-<summary>Add Default Data</summary>
-
-`<WebSite webSiteId="WS_WEBSTORE" siteName= “Wasatchski" productStoreId="WS_STORE" allowProductStoreChange="N" isDefault="N" prodCatalogId="WS_cATALOG" salesChannel="WEB_SALES_CHANNEL"/>`
-
-`<Content contentId="WS_PT_TRUNK" contentTypeId="WEB_SITE_PUB_PT" contentName="Webstore Site's Publish Point" description="Root publish point for WebStore website" statusId="CTNT_PUBLISHED"/>`
-
-`<WebSiteContent webSiteId="WS_WEBSTORE" contentId="WS_PT_TRUNK" webSiteContentTypeId="PUBLISH_POINT" fromDate="2022-07-01 12:00:00.000"/> <Content contentId="WS_KYWRD_SEARCH" contentTypeId="DOCUMENT" statusId="CTNT_PUBLISHED" contentName="WS_Content for category decorator"/> <WebSiteContent webSiteId="WS_WEBSTORE" contentId="WS_KYWRD_SEARCH" fromDate="2022-07-01 12:00:00.000" webSiteContentTypeId="KYWRD_SEARCH"/>`
-
-</details>
+3. **Verify Automated Setup-** After creating the product store, you can verify that the catalog and categories were created correctly:
+   * Navigate to `Settings` > `Product Stores`.
+   * Find your newly created store and click on it to open the `View Product Store` page.
+   * Verify that the `Product Catalog` section shows the correctly linked catalog.
+   * You can also manage additional settings and associations from this view.
 
 These steps create the product store in HotWax Commerce. Ensure facilities that sell products of that brand are linked to the respective store. This association can be accomplished through the following steps:
 


### PR DESCRIPTION
This PR updates the product store creation documentation to align with the new UI-driven and automated process in HotWax OMS. 

**Key Changes:**
- Revised "Create a New Product Store" section to reflect the UI flow (Settings > Product Stores > Create).
- Removed outdated manual XML import steps.
- Documented automated creation of Product Catalog and Categories.
- Verified the screen and automated logic on `dev-oms.hotwax.io`.

Closes #1302 (related to documentation updates)
