### PR TITLE
[codex] fix merged-PR manifest detection for publishing

### DIFF
--- a/.github/workflows/publish-monthly-content.yml
+++ b/.github/workflows/publish-monthly-content.yml
@@ -70,7 +70,7 @@ jobs:
             MONTH="${{ inputs.month }}"
             MANIFEST_PATH="drafts/${MONTH}/publish-manifest.json"
           else
-            MANIFEST_PATH="$(git diff-tree --no-commit-id --name-only -r "${{ github.event.pull_request.merge_commit_sha }}" | grep 'drafts/.*/publish-manifest.json' | head -n 1)"
+            MANIFEST_PATH="$(git diff-tree --no-commit-id --name-only -r -m "${{ github.event.pull_request.merge_commit_sha }}" | grep 'drafts/.*/publish-manifest.json' | head -n 1)"
             if [ -z "$MANIFEST_PATH" ]; then
               echo "No publish manifest found in merged PR."
               exit 1


### PR DESCRIPTION
## What changed
Updated the monthly publish workflow to resolve `publish-manifest.json` from merged pull request commits using `git diff-tree -m`.

## Why
The publish workflow failed for merge commit `72395057114191a85080a1b273b48b359ae5ec3b` before it reached HubSpot. The previous command used `git diff-tree` without `-m`, which returned no changed files for that merge commit, so the workflow exited with `No publish manifest found in merged PR.`

## Impact
Merged monthly content PRs can now correctly locate their manifest and continue into manifest validation and HubSpot publishing.

## Validation
- Verified the updated command returns `drafts/2026-03/publish-manifest.json` for merge commit `72395057114191a85080a1b273b48b359ae5ec3b`
- Ran `git diff --check`