### PR TITLE
[codex] use publish outputs for sync-state PR metadata

### DIFF
--- a/.github/workflows/publish-monthly-content.yml
+++ b/.github/workflows/publish-monthly-content.yml
@@ -100,15 +100,8 @@ jobs:
           SOURCE_REPOS: ${{ vars.SOURCE_REPOS }}
         run: npm run publish:monthly
 
-      - name: Resolve published release notes URL
-        id: published
-        if: steps.guard.outputs.should_publish == 'true' && steps.publish.outcome == 'success'
-        run: |
-          PUBLISHED_URL="$(node -e "const fs = require('fs'); const manifest = JSON.parse(fs.readFileSync(process.env.MANIFEST_PATH, 'utf8')); const state = JSON.parse(fs.readFileSync('state/hubspot-sync-state.json', 'utf8')); const monthState = state.months?.[manifest.month]?.items || {}; const releaseNote = manifest.items.find((item) => item.contentType === 'release-note'); if (!releaseNote) process.exit(1); const publishedUrl = monthState[releaseNote.key]?.hubspotUrl; if (!publishedUrl) process.exit(1); console.log(publishedUrl);" )"
-          echo "release_notes_url=$PUBLISHED_URL" >> "$GITHUB_OUTPUT"
-
       - name: Create or update sync state PR
-        if: steps.guard.outputs.should_publish == 'true' && steps.publish.outcome == 'success'
+        if: steps.guard.outputs.should_publish == 'true' && steps.publish.outcome == 'success' && steps.publish.outputs.release_notes_url != ''
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -120,7 +113,7 @@ jobs:
             Records the HubSpot publish status update for `${{ steps.manifest.outputs.month }}`.
 
             Published release notes:
-            - [${{ steps.manifest.outputs.month }} release notes](${{ steps.published.outputs.release_notes_url }})
+            - [${{ steps.manifest.outputs.month }} release notes](${{ steps.publish.outputs.release_notes_url }})
 
             Merge instructions:
             - Merge this PR after confirming the published page looks correct.

--- a/scripts/publish_monthly_content.js
+++ b/scripts/publish_monthly_content.js
@@ -16,6 +16,14 @@ function resolveManifestPath() {
     throw new Error("MANIFEST_PATH or MONTH must be provided");
 }
 
+function writeGithubOutput(name, value) {
+    if (!process.env.GITHUB_OUTPUT || value == null || value === "") {
+        return;
+    }
+
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`);
+}
+
 async function main() {
     const manifestPath = resolveManifestPath();
     const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
@@ -58,6 +66,12 @@ async function main() {
     }
 
     saveSyncState(state);
+
+    const releaseNote = manifest.items.find((item) => item.contentType === "release-note");
+    const publishedReleaseNotesUrl = releaseNote
+        ? getMonthState(state, manifest.month)[releaseNote.key]?.hubspotUrl || ""
+        : "";
+    writeGithubOutput("release_notes_url", publishedReleaseNotesUrl);
 
     if (failures.length > 0) {
         process.exitCode = 1;


### PR DESCRIPTION
## What changed
Updated `publish_monthly_content.js` to emit the published release-notes URL through GitHub step outputs, and updated the publish workflow to consume that output directly when building the sync-state PR body.

## Why
The previous workflow reopened local files after publish to rediscover the release-notes URL. That extra lookup failed because the step depended on workflow env wiring instead of the publish result itself. Emitting the URL directly from the publish script is simpler and more reliable.

## Validation
- Ran `node --check scripts/publish_monthly_content.js`
- Ran `git diff --check`