### PR TITLE
docs: Add missing NO VARIANCE rejection reason to Order Fulfillment t…

### DIFF
--- a/documents/learn-hotwax-oms/business-processes/order-fulfillment.md
+++ b/documents/learn-hotwax-oms/business-processes/order-fulfillment.md
@@ -79,12 +79,13 @@ They can also configure whether any rejection, predefined or new, should impact 
 
 Let’s see how the out of the box rejection reasons offered by HotWax Commerce impact inventory:
 
-| Rejection Reason | ATP Inventory Change          | QOH Inventory Change          | Selling Impact                                                |
-| ---------------- | ----------------------------- | ----------------------------- | ------------------------------------------------------------- |
-| NOT IN STOCK     | Set to 0                      | Set to 0                      | Prevents new orders until product is back in stock            |
-| MISMATCH         | Decrease by rejected quantity | Decrease by rejected quantity | Product still available but not in specific size or color     |
-| DAMAGE           | Decrease by rejected quantity | Unchanged                     | Product remains in stock but cannot be sold due to damage     |
-| WORN DISPLAY     | Decrease by rejected quantity | Unchanged                     | Product remains in stock but cannot be sold due to being worn |
+| Rejection Reason | ATP Inventory Change          | QOH Inventory Change          | Selling Impact                                                        |
+| ---------------- | ----------------------------- | ----------------------------- | --------------------------------------------------------------------- |
+| NOT IN STOCK     | Set to 0                      | Set to 0                      | Prevents new orders until product is back in stock                    |
+| MISMATCH         | Decrease by rejected quantity | Decrease by rejected quantity | Product still available but not in specific size or color             |
+| DAMAGE           | Decrease by rejected quantity | Unchanged                     | Product remains in stock but cannot be sold due to damage             |
+| WORN DISPLAY     | Decrease by rejected quantity | Unchanged                     | Product remains in stock but cannot be sold due to being worn         |
+| NO VARIANCE      | Unchanged                     | Unchanged                     | Rejection does not affect inventory; used for non-stock-related issues|
 
 Learn more about [Rejections](/documents/store-operations/fulfillment/rejection)
 


### PR DESCRIPTION
Problem Summary
The Order Fulfillment business process documentation contains an incomplete table of default rejection reasons. While it lists 4 rejection reasons (NOT IN STOCK, MISMATCH, DAMAGE, WORN DISPLAY), it's missing the NO VARIANCE rejection reason—which is a critical default option documented in the detailed Rejection page.
Current state:

Order Fulfillment page: 4 rejection reasons in table
Rejection details page: 5 rejection reasons (includes NO VARIANCE)

This creates an inconsistency where users learning the system from the business process overview won't discover that HotWax Commerce provides a rejection option that does not impact inventory.

Closes #1641 