### PR TITLE
Fix typos, grammar, and consistency issues in inventory sync documentation

### DIFF
--- a/documents/additional-integrations/retailpro/flows/inventory/challenges-in-inventory-sync.md
+++ b/documents/additional-integrations/retailpro/flows/inventory/challenges-in-inventory-sync.md
@@ -8,19 +8,19 @@ description: >-
 
 While developing this integration, several challenges surfaced, necessitating additional logic that is uncommon in typical inventory reset syncs. Here are the challenges and their solutions:
 
-### Unfiledtered inventory file
+### Unfiltered inventory file
 
-In a usual setup, ERP systems share a file comprising all active products for inventory synchronization with HotWax Commerce. However, the client's Retail Pro version was able to share a file containing all products ever created in Retail Pro, not just the active ones. This led to an inflated file size, causing prolonged processing times in HotWax Commerce.
+In a usual setup, ERP systems share a file comprising all active products for inventory synchronization with HotWax Commerce. However, the client’s Retail Pro version could only share a file containing all products ever created in Retail Pro, not just the active ones. This led to an inflated file size, causing prolonged processing times in HotWax Commerce.
 
-To address this, we implemented additional logic to filter the file against products created in HotWax from the eCommerce platform. The refined file now only contains inventory by facility for online-published products, significantly reducing file size from 300MB to 70-80KB. HotWax Commerce reads this new file and updates the inventory records, ensuring they match RetailPro's data accurately.
+To address this, we implemented additional logic to filter the file against products created in HotWax from the eCommerce platform. The refined file now only contains inventory by facility for online-published products, significantly reducing file size from 300MB to 70-80KB. HotWax Commerce reads this new file and updates the inventory records, ensuring they match Retail Pro's data accurately.
 
 ### Incorrect inventory counts due to partially shipped orders in HotWax Commerce
 
-HotWax Commerce sends orders to Retail Pro for invoicing, but only fully fulfilled orders are pushed. We will discuss in the Order section on why partially fulfilled orders are excluded. Because partially fulfilled orders are excluded, when Retail Pro sends the morning inventory reset file, it does not account for these scenarios.This discrepancy inflates the inventory count in HotWax Commerce, requiring a meticulous solution.
+HotWax Commerce sends orders to Retail Pro for invoicing, but only fully fulfilled orders are pushed. The reason partially fulfilled orders are excluded is discussed in the Order section. Because partially fulfilled orders are excluded, the morning inventory reset file sent by Retail Pro does not account for these scenarios. This discrepancy inflates the inventory count in HotWax Commerce, requiring a meticulous solution.
 
 To address this, the HotWax Commerce integration platform identifies partially fulfilled orders, calculates the inventory deductions not communicated to Retail Pro, and generates an inventory variance file. This file is loaded in HotWax Commerce after the main reset inventory file, correcting inventory numbers without compromising accuracy. Timing is critical, ensuring that the variance file is processed after the main reset inventory file to avoid inaccuracies.
 
-#### Example showing intricacies of the "Partially Shipped Orders"
+#### Example showing intricacies of the \"Partially Shipped Orders\"
 
 1.  Inventory snapshot in Retail Pro Prism POS and HotWax Commerce at 8:00 AM, showing initial counts for SKUs A, B, and C in New York and Nashville.
 
@@ -48,7 +48,7 @@ To address this, the HotWax Commerce integration platform identifies partially f
     | A   | 2        |
     | B   | 2        |
     | C   | 2        |
-3.  Order is fulfilled for SKU A and B in Hotwax Commerce from NY at 9:00 AM. Inventory snapshot after order fulfillment in Retail Pro and HotWax Commerce:
+3.  The order is fulfilled for SKUs A and B in HotWax Commerce from New York at 9:00 AM. Inventory snapshot after order fulfillment in Retail Pro and HotWax Commerce:
 
     **Inventory snapshot at Retail Pro:**
 
@@ -58,7 +58,7 @@ To address this, the HotWax Commerce integration platform identifies partially f
     | B            | 10       | 10        |
     | C            | 0        | 0         |
 
-    **Inventorty snapshot at HotWax Commerce:**
+    **Inventory snapshot at HotWax Commerce:**
 
     Updated inventory snapshot in HotWax Commerce after the fulfillment of the customer order, reflecting adjusted counts for SKUs A, B, and C.
 
@@ -67,7 +67,7 @@ To address this, the HotWax Commerce integration platform identifies partially f
     | A            | 8        | 10        |
     | B            | 8        | 10        |
     | C            | 0        | 0         |
-4.  Retail Pro is unaware of the partial fulfillment in HC, sends an Inventory Reset file the next morning at 7:00 AM. The file includes counts of 10 for SKU A and SKU B across both New York and Nashville, not accounting for the partial fulfillment. This table represents the inventory file including new inventory for SKU C at each location.
+4.  Retail Pro, being unaware of the partial fulfillment in HotWax Commerce, sends an Inventory Reset file the next morning at 7:00 AM. The file includes counts of 10 for SKU A and SKU B across both New York and Nashville, not accounting for the partial fulfillment. This table represents the inventory file including new inventory for SKU C at each location.
 
     **Inventory Reset file from Retail Pro:**
 
@@ -76,7 +76,7 @@ To address this, the HotWax Commerce integration platform identifies partially f
     | A            | 10       | 10        |
     | B            | 10       | 10        |
     | C            | 5        | 5         |
-5.  When this file is read by HotWax Commerce, inventory counts of SKU A and B and C are reset. Reset for SKU C is correct; however, SKU of A & B to 10 at NY is incorrect. Ideally SKU of A and B at NY should be 8.
+5.  When this file is read by HotWax Commerce, inventory counts of SKUs A, B, and C are reset. The reset for SKU C is correct; however, resetting SKUs A and B to 10 in New York is incorrect. Ideally, SKUs A and B in New York should be 8.
 
     **Inventory snapshot at HotWax Commerce:**
 


### PR DESCRIPTION
Fixes #1639

This PR addresses typos, grammatical errors, and consistency issues identified in the inventory sync documentation for Retail Pro integration.

### Changes:
- Corrected typos: \"Unfiledtered\" -> \"Unfiltered\", \"Inventorty\" -> \"Inventory\".
- Standardized product names: \"HotWax Commerce\" and \"Retail Pro\".
- Improved grammar and sentence structure for better readability.
- Replaced abbreviations (e.g., \"NY\" -> \"New York\", \"HC\" -> \"HotWax Commerce\").
- Standardized singular/plural usage of \"SKU/SKUs\".
- Fixed missing spaces after periods.