### PR TITLE
Fix broken "Order Routing" link in Brokering Queue documentation

### DIFF
--- a/documents/learn-hotwax-oms/README.md
+++ b/documents/learn-hotwax-oms/README.md
@@ -51,7 +51,7 @@ The brokering queue serves as a waiting area for orders awaiting processing in t
 
 For example, if the brokering engine runs every three hours starting at 9:00 A.M., orders placed and approved at 10:00 A.M. will remain in the brokering queue until the next brokering engine run at 12:00 P.M. Similarly, orders placed and approved at 11:30 A.M. will also be processed at 12:00 P.M.
 
-Learn more about [order routing](../retail-operations/orders/order-routing.md).
+Learn more about [order routing](../retail-operations/orders/order-routing/README.md).
 
 ### Bundle product
 


### PR DESCRIPTION
Replaced the incorrect GitHub URL with the correct relative documentation path for the "Order Routing" section.

This resolves the 404 error and ensures users can navigate properly from the Brokering Queue documentation.