### PR TITLE
fix: correct NetSuite capitalization and broken bold formatting in netsuite sync report

### DIFF
--- a/documents/analytics/reports/netsuitesync.md
+++ b/documents/analytics/reports/netsuitesync.md
@@ -427,7 +427,7 @@ LIMIT 1000;
 
 **Data Selection:** The query begins by selecting data from various tables that hold information on return transactions, products, and orders. Key details include return ID, entry date, order name, internal product name (SKU), facility ID, returned quantity, and restocked quantity.
 
-**Filtering Return Transactions: ** The report specifically looks at returns that are not directed to the generic facility '_NA_'. This helps in focusing on relevant return transactions.
+**Filtering Return Transactions:** The report specifically looks at returns that are not directed to the generic facility '_NA_'. This helps in focusing on relevant return transactions.
 
 **Joining Relevant Tables:** To gather comprehensive data, the SQL query joins multiple tables. The return header table (rh) contains general return information such as destination facility ID and entry date. The return item table (ri) provides details on individual returned items and their quantities. The product table (p) includes product details such as internal name (SKU), and the order header table (oh) links returns to their corresponding orders.
 

--- a/documents/analytics/reports/netsuitesync.md
+++ b/documents/analytics/reports/netsuitesync.md
@@ -1,8 +1,8 @@
 ---
-description: Discover Netsuite synchronization reports provided by HotWax Commerce
+description: Discover NetSuite synchronization reports provided by HotWax Commerce
 ---
 
-# Netsuite Sync
+# NetSuite Sync
 
 ## Missing Products from Order
 
@@ -73,7 +73,7 @@ This report identifies products listed on Shopify that are missing from NetSuite
 
 <details>
 
-<summary>SQL Query to Generate Product without Netsuite Order ID Report</summary>
+<summary>SQL Query to Generate Product without NetSuite Order ID Report</summary>
 
 ```sql
 SELECT sku AS sku,
@@ -427,7 +427,7 @@ LIMIT 1000;
 
 **Data Selection:** The query begins by selecting data from various tables that hold information on return transactions, products, and orders. Key details include return ID, entry date, order name, internal product name (SKU), facility ID, returned quantity, and restocked quantity.
 
-\*\*Filtering Return Transactions:\*8 The report specifically looks at returns that are not directed to the generic facility '_NA_'. This helps in focusing on relevant return transactions.
+**Filtering Return Transactions: ** The report specifically looks at returns that are not directed to the generic facility '_NA_'. This helps in focusing on relevant return transactions.
 
 **Joining Relevant Tables:** To gather comprehensive data, the SQL query joins multiple tables. The return header table (rh) contains general return information such as destination facility ID and entry date. The return item table (ri) provides details on individual returned items and their quantities. The product table (p) includes product details such as internal name (SKU), and the order header table (oh) links returns to their corresponding orders.
 


### PR DESCRIPTION
Summary
Fixes typos and formatting issues in the NetSuite sync reports page.

 Changes
- Fixed broken bold markdown: `\*\*Filtering Return Transactions:\*8` → `**Filtering Return Transactions:**` in POS Returns vs Restock section
- Fixed "Netsuite" → "NetSuite" in two section headings:
  - "Products without Netsuite Order ID Report"
  - "Customer Without Netsuite Id Report"

 Page affected
https://docs.hotwax.co/documents/analytics/reports/netsuitesync

