### PR TITLE
fix: resolve HTTP links, double slash path and case mismatch in docs

### DIFF
--- a/documents/learn-hotwax-oms/how-to-guides/configure-store-fulfillment.md
+++ b/documents/learn-hotwax-oms/how-to-guides/configure-store-fulfillment.md
@@ -68,7 +68,7 @@ When the inventory is received, a product’s QOH and Online ATP are updated in 
 
 Online ATP = QOH - (Reserved quantities + Safety stock + Threshold + Orders in brokering queue + Excluded facilities' ATP)
 
-For each store that allows online fulfillment, HotWax Commerce calculates the Online ATP that is available to sell and synchronize the inventory with Shopify through [Hard Sync and \`Update recent inventory changes jobs](/documents/retail-operations/workflow/job-workflows/inventory).
+For each store that allows online fulfillment, HotWax Commerce calculates the Online ATP available to sell and synchronizes the inventory with Shopify through the [`Hard Sync` and `Update Recent Inventory Changes` jobs](/documents/retail-operations/workflow/job-workflows/inventory).
 
 ### Verify Store Fulfillment
 

--- a/documents/learn-hotwax-oms/how-to-guides/configure-store-fulfillment.md
+++ b/documents/learn-hotwax-oms/how-to-guides/configure-store-fulfillment.md
@@ -68,7 +68,7 @@ When the inventory is received, a product’s QOH and Online ATP are updated in 
 
 Online ATP = QOH - (Reserved quantities + Safety stock + Threshold + Orders in brokering queue + Excluded facilities' ATP)
 
-For each store that allows online fulfillment, HotWax Commerce calculates the Online ATP that is available to sell and synchronize the inventory with Shopify through [Hard Sync and \`Update recent inventory changes jobs](/documents/retail-operations//workflow/job-workflows/inventory).
+For each store that allows online fulfillment, HotWax Commerce calculates the Online ATP that is available to sell and synchronize the inventory with Shopify through [Hard Sync and \`Update recent inventory changes jobs](/documents/retail-operations/workflow/job-workflows/inventory).
 
 ### Verify Store Fulfillment
 

--- a/documents/learn-netsuite/netsuite-deployment/SUMMARY.md
+++ b/documents/learn-netsuite/netsuite-deployment/SUMMARY.md
@@ -12,7 +12,7 @@
 ## Prerequisites
 
 * [Install NetSuite Jobs](prerequisite-syncs/install-netsuite-reader.md)
-* [Product Store Settings](prerequisite-syncs/productStore-settings.md)
+* [Product Store Settings](prerequisite-syncs/productstore-settings.md)
 * [SFTP Locations](prerequisite-syncs/sftp-locations.md)
 * [Historical Customers](prerequisite-syncs/historical-customers.md)
 * [Shipping Methods](prerequisite-syncs/shipping-methods.md)

--- a/documents/learn-shopify/initial-sync/README.md
+++ b/documents/learn-shopify/initial-sync/README.md
@@ -22,7 +22,7 @@ Execute the job of processing bulk imported files by accessing the "Process Bulk
 
 To initiate the import of products from Shopify, a crucial step before importing other data, follow these steps using the Initial Load page in the Job Manager app:
 
-1. Visit [job-manager.hotwax.io](https://job-manager.hotwax.io).
+1. Visit [Job Manager](https://job-manager.hotwax.io).
 2. Navigate to the Initial Load section.
 3. Click on "Import products in bulk."
 4. Choose the desired run time and initiate the import by clicking the "Run Import" button.

--- a/documents/learn-shopify/initial-sync/README.md
+++ b/documents/learn-shopify/initial-sync/README.md
@@ -22,7 +22,7 @@ Execute the job of processing bulk imported files by accessing the "Process Bulk
 
 To initiate the import of products from Shopify, a crucial step before importing other data, follow these steps using the Initial Load page in the Job Manager app:
 
-1. Visit [job-manager.hotwax.io](http://job-manager.hotwax.io).
+1. Visit [job-manager.hotwax.io](https://job-manager.hotwax.io).
 2. Navigate to the Initial Load section.
 3. Click on "Import products in bulk."
 4. Choose the desired run time and initiate the import by clicking the "Run Import" button.

--- a/documents/learn-shopify/initial-sync/import-orders.md
+++ b/documents/learn-shopify/initial-sync/import-orders.md
@@ -11,7 +11,7 @@ To download all open sales orders from a specific period in HotWax Commerce, use
 
 **To import orders in HotWax Commerce, follow these steps:**
 
-1. Visit [job-manager.hotwax.io](http://job-manager.hotwax.io).
+1. Visit [job-manager.hotwax.io](https://job-manager.hotwax.io).
 2. Navigate to the Initial Load section.
 3. Click on "Import Orders in bulk."
 4. Choose the desired run time.

--- a/documents/learn-shopify/initial-sync/import-orders.md
+++ b/documents/learn-shopify/initial-sync/import-orders.md
@@ -11,7 +11,7 @@ To download all open sales orders from a specific period in HotWax Commerce, use
 
 **To import orders in HotWax Commerce, follow these steps:**
 
-1. Visit [job-manager.hotwax.io](https://job-manager.hotwax.io).
+1. Visit [Job Manager](https://job-manager.hotwax.io).
 2. Navigate to the Initial Load section.
 3. Click on "Import Orders in bulk."
 4. Choose the desired run time.


### PR DESCRIPTION
## Summary

This PR fixes **3 issues** found during a full automated scan of 492 markdown files in the `documents/` directory.

> Full audit details in issue [#1676](https://github.com/hotwax/oms-documentation/issues/1676).

---

## Changes Made

| File | Line | Fix |
|---|---|---|
| `learn-shopify/initial-sync/README.md` | L25 | `http://` → `https://` for `job-manager.hotwax.io` |
| `learn-shopify/initial-sync/import-orders.md` | L14 | `http://` → `https://` for `job-manager.hotwax.io` |
| `how-to-guides/configure-store-fulfillment.md` | L71 | Removed double slash `//` in workflow path |
| `netsuite-deployment/SUMMARY.md` | L15 | Fixed case mismatch: `productStore-settings.md` → `productstore-settings.md` |

---

## Remaining Issues

4 broken relative links (missing files) are tracked in issue [#1676](https://github.com/hotwax/oms-documentation/issues/1676) and need content decisions from maintainers:

- `learn-hotwax-oms/README.md` — 3 broken links (packing slips, pre-orders, safety stock)
- `how-to-guides/configure-store-fulfillment.md` — missing page for `configure-fulfillment-capacity`