### PR TITLE
docs(store-operations/fulfillment/open-orders): Fix pronoun usage and page name inconsistency

### DIFF
--- a/documents/store-operations/fulfillment/open-orders.md
+++ b/documents/store-operations/fulfillment/open-orders.md
@@ -81,7 +81,7 @@ It displays:
 - Customer details (name, phone number, and full address)  
 - Details of other shipments in the order  
 
-The same details are also shown when viewing the Order Details Page in the `In Progress` and `Completed` tabs.
+The same details are also shown when viewing the `Order Details` page in the `In Progress` and `Completed` tabs.
 
 From this page, store associates can:  
 - Pick the order if items are available  

--- a/documents/store-operations/fulfillment/open-orders.md
+++ b/documents/store-operations/fulfillment/open-orders.md
@@ -13,9 +13,9 @@ Whenever a new order is assigned to a store for fulfillment, store associates re
 ### Shipping Methods
 Store associates can filter orders by shipping method.  
 
-- To see same-day delivery orders, filter them by `Same Day`  
-- To see next-day delivery orders, filter them by `Next Day`  
-- To see standard delivery orders, filter them by `Standard`
+- Filter by `Same Day` to see same-day delivery orders
+- Filter by `Next Day` to see next-day delivery orders
+- Filter by `Standard` to see standard delivery orders
 
 ### Picklist Size
 By default, you see 10 orders in a page. To increase the number of orders to be displayed, tap the `Picklist Size` in the top right corner and choose the number of orders you want to see at once.

--- a/documents/store-operations/fulfillment/open-orders.md
+++ b/documents/store-operations/fulfillment/open-orders.md
@@ -13,9 +13,9 @@ Whenever a new order is assigned to a store for fulfillment, store associates re
 ### Shipping Methods
 Store associates can filter orders by shipping method.  
 
-- To see same-day delivery orders, filter it by `Same Day`  
-- To see next-day delivery orders, filter it by `Next Day`  
-- To see standard delivery orders, filter it by `Standard`
+- To see same-day delivery orders, filter them by `Same Day`  
+- To see next-day delivery orders, filter them by `Next Day`  
+- To see standard delivery orders, filter them by `Standard`
 
 ### Picklist Size
 By default, you see 10 orders in a page. To increase the number of orders to be displayed, tap the `Picklist Size` in the top right corner and choose the number of orders you want to see at once.
@@ -81,7 +81,7 @@ It displays:
 - Customer details (name, phone number, and full address)  
 - Details of other shipments in the order  
 
-The same details are also shown when viewing the Orders Details Page in the `In Progress` and `Completed` tabs.
+The same details are also shown when viewing the Order Details Page in the `In Progress` and `Completed` tabs.
 
 From this page, store associates can:  
 - Pick the order if items are available  


### PR DESCRIPTION
## Summary
Fixes grammar and consistency issues in the Store Operations > Fulfillment App > Open Orders documentation as reported in #1681.

## Changes Made

### Issue 1: Pronoun Mismatch in Shipping Method Filters
**Location:** Store Operations > Fulfillment App > Open Orders > Filters > Shipping Methods

Changed singular pronoun "it" to plural "them" to correctly reference the plural noun "orders":
- "To see same-day delivery orders, filter them by `Same Day`"
- "To see next-day delivery orders, filter them by `Next Day`"
- "To see standard delivery orders, filter them by `Standard`"

### Issue 2: Page Name Inconsistency
**Location:** Store Operations > Fulfillment App > Open Orders > Order Details Page

Corrected "Orders Details Page" to "Order Details Page" to maintain naming consistency with the actual section heading throughout the document.

## Files Changed
- `documents/store-operations/fulfillment/open-orders.md`

## Resolves
Closes #1681