### PR TITLE
Fix typo on product download page

### DIFF
--- a/documents/learn-shopify/shopify-integration/products/download-products.md
+++ b/documents/learn-shopify/shopify-integration/products/download-products.md
@@ -1,5 +1,5 @@
 ---
-description: Learn how to launch the initial product download from Shopify.
+description: Learn how to download products from Shopify to HotWax Commerce.
 ---
 
 # Product Download

--- a/documents/learn-shopify/shopify-integration/products/download-products.md
+++ b/documents/learn-shopify/shopify-integration/products/download-products.md
@@ -1,5 +1,5 @@
 ---
-description: Learn how launch the initial product download from Shopify.
+description: Learn how to launch the initial product download from Shopify.
 ---
 
 # Product Download


### PR DESCRIPTION
Summary

Fixed a typo in the Description heading of the Shopify product download documentation page.

 Changes

Added the missing word `to` in the sentence:

  * `Learn how to launch the initial product download from Shopify.`

File Updated

`documents/learn-shopify/shopify-integration/products/download-products.md`
