### PR TITLE
Document Shopify order tag updates

### DIFF
--- a/documents/learn-shopify/shopify-integration/orders/order-updates.md
+++ b/documents/learn-shopify/shopify-integration/orders/order-updates.md
@@ -17,25 +17,25 @@ To ensure all order modifications are synced accurately, HotWax Commerce has an 
 
 <figure><img src="../../.gitbook/assets/import-order-updates-job-config.png" alt=""><figcaption><p><em>Fig.6 : Configuration of the “Import order updates from Shopify” job in the Job Manager App</em></p></figcaption></figure>
 
-### Synchronizing Shopify Order Tags
+### Syncing Shopify order tags
 
 Shopify order tags are also included in order updates. This allows merchants to use Shopify Flow, fraud tools, or customer service workflows to update an order's handling instructions after the order is created.
 
-For example, merchants can configure Shopify Flow to apply a `HOLD` tag when an order needs manual review and an `APPROVED` tag when the order is ready for fulfillment. HotWax Commerce syncs these tag changes from Shopify so the OMS can use the latest tag values when deciding whether an order should remain in brokering or move forward to facility allocation.
+For example, merchants can configure Shopify Flow to apply a `HOLD` tag when an order needs manual review and an `APPROVED` tag when the order is ready for fulfillment. HotWax Commerce syncs these tag changes from Shopify so the order management system (OMS) can use the latest tag values when deciding whether an order should remain in brokering or proceed to facility allocation.
 
-#### HOLD and APPROVED Tag Flow
+#### HOLD and APPROVED tag flow
 
 1. A customer places an order in Shopify.
 2. Shopify Flow evaluates the order against the merchant's review conditions, such as order value, risk level, or product-specific rules.
 3. If the order requires review, Shopify Flow adds the `HOLD` tag. The order remains in the brokering queue and is not allocated to a facility.
-4. After a CSR reviews the order in Shopify, the CSR removes the `HOLD` tag and adds the `APPROVED` tag.
+4. After a customer service representative (CSR) reviews the order in Shopify, the CSR removes the `HOLD` tag and adds the `APPROVED` tag.
 5. The 'Import order updates from Shopify' job syncs the updated tags to HotWax Commerce.
 6. On the next allocation run, orders with the `APPROVED` tag become eligible for facility allocation and fulfillment.
 
 If the order does not meet any manual-review condition, Shopify Flow can add the `APPROVED` tag automatically. In that case, once the order is downloaded and the tag is synced, the order can proceed through the standard allocation process.
 
 {% hint style="info" %}
-When merchants use an approval-based tag flow, the `APPROVED` tag is required before an order can move forward to allocation and fulfillment. Orders without the required approval tag remain in the brokering queue until Shopify is updated and the tag change is synced.
+When merchants use an approval-based tag flow, the `APPROVED` tag is required before an order can proceed to allocation and fulfillment. Orders without the required approval tag remain in the brokering queue until Shopify is updated and the tag change is synced.
 {% endhint %}
 
-To know more about how HotWax Commerce synchronizes order fulfillment updates with Shopify, read the [Shopify integration overview](../../). Read further to know how HotWax Commerce manages [Presell orders](../preorders-and-backorders/) and [BOPIS Orders](../bopis-orders/).
+To learn more about how HotWax Commerce syncs order fulfillment updates with Shopify, read the [Shopify integration overview](../../). Read further to learn how HotWax Commerce manages [Presell orders](../preorders-and-backorders/) and [BOPIS orders](../bopis-orders/).

--- a/documents/learn-shopify/shopify-integration/orders/order-updates.md
+++ b/documents/learn-shopify/shopify-integration/orders/order-updates.md
@@ -17,4 +17,25 @@ To ensure all order modifications are synced accurately, HotWax Commerce has an 
 
 <figure><img src="../../.gitbook/assets/import-order-updates-job-config.png" alt=""><figcaption><p><em>Fig.6 : Configuration of the “Import order updates from Shopify” job in the Job Manager App</em></p></figcaption></figure>
 
-To know more about how HotWax Commerce synchronizes Order fulfillment updates with Shopify, [click here](../../). Read further to know how HotWax Commerce Manages [Presell orders](../preorders-and-backorders/) and [BOPIS Orders](../bopis-orders/).
+### Synchronizing Shopify Order Tags
+
+Shopify order tags are also included in order updates. This allows merchants to use Shopify Flow, fraud tools, or customer service workflows to update an order's handling instructions after the order is created.
+
+For example, merchants can configure Shopify Flow to apply a `HOLD` tag when an order needs manual review and an `APPROVED` tag when the order is ready for fulfillment. HotWax Commerce syncs these tag changes from Shopify so the OMS can use the latest tag values when deciding whether an order should remain in brokering or move forward to facility allocation.
+
+#### HOLD and APPROVED Tag Flow
+
+1. A customer places an order in Shopify.
+2. Shopify Flow evaluates the order against the merchant's review conditions, such as order value, risk level, or product-specific rules.
+3. If the order requires review, Shopify Flow adds the `HOLD` tag. The order remains in the brokering queue and is not allocated to a facility.
+4. After a CSR reviews the order in Shopify, the CSR removes the `HOLD` tag and adds the `APPROVED` tag.
+5. The 'Import order updates from Shopify' job syncs the updated tags to HotWax Commerce.
+6. On the next allocation run, orders with the `APPROVED` tag become eligible for facility allocation and fulfillment.
+
+If the order does not meet any manual-review condition, Shopify Flow can add the `APPROVED` tag automatically. In that case, once the order is downloaded and the tag is synced, the order can proceed through the standard allocation process.
+
+{% hint style="info" %}
+When merchants use an approval-based tag flow, the `APPROVED` tag is required before an order can move forward to allocation and fulfillment. Orders without the required approval tag remain in the brokering queue until Shopify is updated and the tag change is synced.
+{% endhint %}
+
+To know more about how HotWax Commerce synchronizes order fulfillment updates with Shopify, read the [Shopify integration overview](../../). Read further to know how HotWax Commerce manages [Presell orders](../preorders-and-backorders/) and [BOPIS Orders](../bopis-orders/).


### PR DESCRIPTION
## Summary
- Adds Shopify order tag sync details to the Order Updates documentation
- Documents the HOLD/APPROVED tag flow for approval-based fulfillment
- Replaces non-descriptive link text on the same page so markdownlint passes

Closes #1408

## Verification
- npx --yes markdownlint-cli2 documents/learn-shopify/shopify-integration/orders/order-updates.md
- git diff --check