### PR TITLE
docs: update Data Manager documentation for Maarg architecture

### DIFF
--- a/documents/system-admin/administration/data-manager/README.md
+++ b/documents/system-admin/administration/data-manager/README.md
@@ -10,7 +10,7 @@ Key features and functionalities include:
 1. **Manual Data Import and Export:** Manually import or extract data as needed.
 2. **Multithreaded:** Import large amounts of data at high speeds to keep the OMS in sync with external systems.
 3. **Error notifications:** Automatically get notified when an error occurs during import.
-4. **Audit imported data:** Audit imported files as they were provided, ensuring traceability.
+4. **Audit imported data:** Audit imported files as they were provided for traceability.
 
 ## MDM Under the Hood
 Understanding the inner workings of the OMS MDM is essential to building scalable integrations, troubleshooting integrations, and amending corrupted data.
@@ -50,7 +50,7 @@ To make the MDM more approachable for starters, we've identified the most common
 We aim to soon publish a more comprehensive list of available services in the MDM.
 
 ### Execution
-The MDM processes imports across two dedicated thread pools — **Priority** and **Normal** — based on the priority configured for each configuration. When a file is submitted, the MDM runner places it into the appropriate pool's queue. You have three execution modes to choose from when setting up a configuration:
+The MDM processes imports across two dedicated thread pools, **Priority** and **Normal**, based on the priority configured for each configuration. When a file is submitted, the MDM runner places it into the appropriate pool's queue. You have three execution modes to choose from when setting up a configuration:
 
 1. **Queued:** The default and recommended mode. Configurations in this mode respect the order (FIFO) within their assigned thread pool queue.
 2. **Sync:** Files uploaded to a configuration set to execute in sync will be processed immediately by the OMS. Uploading large files to a configuration set to execute in sync will almost certainly be fatal because it will demand that the OMS route all required resources to process the file immediately. As a general rule, just don't use this setting unless very specifically instructed.
@@ -109,7 +109,7 @@ A `Pending` import can be cancelled by clicking the **X** button on the log entr
 
 Understanding how the MDM stores files is important for managing server disk space and data privacy:
 
-* **File Upload:** When a file is submitted (either manually via the UI or pulled via SFTP), it is immediately saved to the server's local storage (`runtime/datamanager/imported/{configId}/`) before any processing begins. The log entry is created in `Pending` status and linked to this file.
-* **Error Files:** If an import finishes with failed records, the MDM generates a separate error file containing the failed rows and their error reasons. This error file is stored in the same directory as the original file.
-* **Temporary Processing Files:** When multi-threading is enabled, the MDM splits the large file into smaller chunks. These chunks are stored in a temporary directory (`runtime/tmp/DM_{logId}/`) and are automatically deleted by the system once the import finishes.
-* **Data Retention:** Files remain on the server disk as long as their corresponding Data Manager log entry exists. **Deleting a log entry from the UI permanently deletes the original file and any associated error files from the server's physical disk**, freeing up space.
+* **File Upload:** When a file is submitted (either manually via the UI or pulled via SFTP), it is immediately saved to the server's local storage (`runtime/datamanager/imported/{configId}/`) before any processing begins. The log entry is created in `Pending` status and linked to this file
+* **Error Files:** If an import finishes with failed records, the MDM generates a separate error file containing the failed rows and their error reasons. This error file is stored in the same directory as the original file
+* **Temporary Processing Files:** When multi-threading is enabled, the MDM splits the large file into smaller chunks. These chunks are stored in a temporary directory (`runtime/tmp/DM_{logId}/`) and are automatically deleted by the system once the import finishes
+* **Data Retention:** Files remain on the server disk as long as their corresponding Data Manager log entry exists. **Deleting a log entry from the UI permanently deletes the original file and any associated error files from the server's physical disk**

--- a/documents/system-admin/administration/data-manager/README.md
+++ b/documents/system-admin/administration/data-manager/README.md
@@ -1,17 +1,16 @@
 # Data Manager
 
-The Data Manager allows users audit data ingress and egress from the OMS while also being able to manually import and export data.
+The Data Manager allows users to audit data ingress and egress from the OMS while also being able to manually import and export data.
 
-Getting to the Data Manager Configurations page:
+Getting to the Data Manager page:
 1. Go to the Hamburger Menu
-2. Select `Settings`
-3. Click on `Data Manager Configurations`
+2. Select `MDM`
 
 Key features and functionalities include:
 1. **Manual Data Import and Export:** Manually import or extract data as needed.
 2. **Multithreaded:** Import large amounts of data at high speeds to keep the OMS in sync with external systems.
 3. **Error notifications:** Automatically get notified when an error occurs during import.
-4. **Audit imported data:** Audit imported files as they were provided, ensuring tracability.
+4. **Audit imported data:** Audit imported files as they were provided, ensuring traceability.
 
 ## MDM Under the Hood
 Understanding the inner workings of the OMS MDM is essential to building scalable integrations, troubleshooting integrations, and amending corrupted data.
@@ -19,7 +18,7 @@ Understanding the inner workings of the OMS MDM is essential to building scalabl
 ### Configurations
 A data manager configuration represents the import settings for a type of data. For example, importing sales orders from Shopify, fulfillment from a 3PL, or inventory from a POS are all separate configurations because they are all importing different types of data.
 
-The primary function of a configuration is defined by the import and export services configured in it. Looking at the examples above, here is how that would work:
+The primary function of a configuration is defined by the import service configured in it. Looking at the examples above, here is how that would work:
 
 | Config Name                       | Import service                 |
 | --------------------------------- | ------------------------------ |
@@ -39,7 +38,7 @@ To better accommodate this kind of setup, all we'll need to do is rename the POS
 | ---------------------------------------- | ------------------------------ |
 | Import orders from Shopify               | importShopifyOrders            |
 | Import order fulfillment from 3PL        | fulfillOrderItem               |
-| Reset inventory ~~from POS~~ | resetInventoryByIdentification |
+| Reset inventory ~~from POS~~             | resetInventoryByIdentification |
 
 ### Available Functions
 The MDM becomes truly powerful once you understand that any service in the OMS can be turned into a data manager configuration.
@@ -49,16 +48,17 @@ Essentially, what happens when you assign an import service to an MDM, is that t
 To make the MDM more approachable for starters, we've identified the most commonly used configurations and organized them on the EXIM (Export Import) page. You can, however, see all configurations in the Data Manager Configurations page.
 
 We aim to soon publish a more comprehensive list of available services in the MDM.
+
 ### Execution
-The MDM is one unified import queue across all configurations. When a file is added to the MDM to be processed, the OMS looks at its execution mode to determine how to prioritize it. You have three options to choose from when setting up a configuration:
+The MDM processes imports across two dedicated thread pools — **Priority** and **Normal** — based on the priority configured for each configuration. When a file is submitted, the MDM runner places it into the appropriate pool's queue. You have three execution modes to choose from when setting up a configuration:
 
-1. **Queued:** Queued configurations will respect the FIFO order of the entire MDM.
-2. **Sync:** Files uploaded to a configuration set to execute in sync will be processed immediately by the OMS. Uploading large files to a configuration set to execute in-sync will almost certainly be fatal because it will demand that the OMS route all required resources to process the file immediately. As a general rule, just don't use this setting unless very specifically instructed.
-3. **Async:** Similar to sync, these configurations will not follow the FIFO order that queued imports follow. Instead, an async import will process in the background when threads are available.
+1. **Queued:** The default and recommended mode. Configurations in this mode respect the order (FIFO) within their assigned thread pool queue.
+2. **Sync:** Files uploaded to a configuration set to execute in sync will be processed immediately by the OMS. Uploading large files to a configuration set to execute in sync will almost certainly be fatal because it will demand that the OMS route all required resources to process the file immediately. As a general rule, just don't use this setting unless very specifically instructed.
+3. **Async:** Similar to sync, these configurations will not follow the queued order of their pool. Instead, an async import will process in the background when threads are available.
 
-To understand how these work in practice lets look at an example.
+To understand how these work in practice, let's look at an example.
 
-Here are the three configurations we have setup for import
+Here are the three configurations we have set up for import:
 
 | Config                   | Import service                 | Execution mode |
 | ------------------------ | ------------------------------ | -------------- |
@@ -75,9 +75,41 @@ Here is an example MDM state at this point:
 | Reset inventory       | resetInventoryByIdentification | Queued         | 4:00 am        |
 | Import Shopify orders | importShopifyOrders            | Queued         | 4:15 am        |
 
-All orders placed after the morning inventory file is submitted will not be processed in the OMS until the reset inventory file is finished processing. While this may seem problematic at first because orders are not being processed as they're being placed, the time of day when this operation happens is important to consider. Inventory update processing is happening somewhere between 12 a.m. - 4 a.m. during which no fulfillment operations are running; therefore, orders processing after the inventory file finishes does not actually hurt a retailer’s fulfillment SLA.
+All orders placed after the morning inventory file is submitted will not be processed in the OMS until the reset inventory file is finished processing. While this may seem problematic at first because orders are not being processed as they're being placed, the time of day when this operation happens is important to consider. Inventory update processing is happening somewhere between 12 a.m. - 4 a.m. during which no fulfillment operations are running; therefore, orders processing after the inventory file finishes does not actually hurt a retailer's fulfillment SLA.
 
-#### Queue poller
-All file import tasks enter the MDM queue in a `Pending` status. As the poller works its way through the queue, it transitions the current active file to a `Running` status. The frequency that the poller checks for pending files can be configured using the Process Bulk Imported Files job in the job manager app. Every time the poller runs, it registers all `Pending` items in the queue and will continue to run until all the pending files at the time of polling are finished processing.
+#### MDM Runner and Thread Pools
+The MDM uses a runner-based architecture with two dedicated worker pools:
 
-During this time, other scheduled occurrences of the queue poller job, Process Bulk Imported Files, may take place, but since there is already an instance of the file processor active, it will cancel itself. In the job manager app, this may look like an error that needs to be resolved but is normal behavior.
+- **Priority Pool:** Handles imports from configurations with a higher priority value. Each pool has a fixed number of threads and a bounded queue. When the active thread count equals the maximum pool size, the pool is shown in a warning state. If the queue is full, it is shown in a danger state.
+- **Normal Pool:** Handles all other imports. Operates identically to the Priority Pool but is used for standard-priority configurations.
+
+Each pool exposes live metrics on the Find Import page:
+- **Threads:** Active threads, current pool size, and maximum pool size.
+- **Queue:** Current queue depth and remaining capacity.
+- **Last runner executed at:** The timestamp of the last MDM runner execution.
+
+The thread pool a configuration is routed to is determined automatically based on its configured `Priority` value and is visible as the **Thread Pool** field on the configuration detail page.
+
+#### Import Statuses
+Each import log entry progresses through the following statuses:
+
+| Status      | Description                                                                                             |
+| ----------- | ------------------------------------------------------------------------------------------------------- |
+| **Pending** | The file has been submitted and is waiting to be picked up by the MDM runner.                           |
+| **Queued**  | The runner has picked up the file and placed it in the worker pool queue.                               |
+| **Running** | The file is actively being processed by a worker thread.                                                |
+| **Finished**| Processing completed successfully.                                                                      |
+| **Failed**  | Processing completed but encountered a failure.                                                         |
+| **Crashed** | The runner or worker thread terminated unexpectedly during processing.                                  |
+| **Cancelled**| The import was manually cancelled by a user before or during processing.                               |
+
+A `Pending` import can be cancelled by clicking the **X** button on the log entry before the runner picks it up.
+
+#### File Storage and Retention
+
+Understanding how the MDM stores files is important for managing server disk space and data privacy:
+
+* **File Upload:** When a file is submitted (either manually via the UI or pulled via SFTP), it is immediately saved to the server's local storage (`runtime/datamanager/imported/{configId}/`) before any processing begins. The log entry is created in `Pending` status and linked to this file.
+* **Error Files:** If an import finishes with failed records, the MDM generates a separate error file containing the failed rows and their error reasons. This error file is stored in the same directory as the original file.
+* **Temporary Processing Files:** When multi-threading is enabled, the MDM splits the large file into smaller chunks. These chunks are stored in a temporary directory (`runtime/tmp/DM_{logId}/`) and are automatically deleted by the system once the import finishes.
+* **Data Retention:** Files remain on the server disk as long as their corresponding Data Manager log entry exists. **Deleting a log entry from the UI permanently deletes the original file and any associated error files from the server's physical disk**, freeing up space.

--- a/documents/system-admin/administration/data-manager/configuration-options.md
+++ b/documents/system-admin/administration/data-manager/configuration-options.md
@@ -32,7 +32,7 @@ Execution mode should always be set to Queued.
 {% endhint %}
 
 {% hint style="danger" %}
-Multi-threading should be disabled on all configs unless explicitly instructed by HotWax Support. Incorrect use of multi-threading can cause system overload and downtime. If multi-threading is enabled, ensure the configuration is set to execute in Queued mode, or you risk causing a system overload.
+Multi-threading should be disabled on all configs unless explicitly instructed by HotWax Support. Incorrect use of multi-threading can cause system overload and downtime. If multi-threading is enabled, the configuration must be set to execute in Queued mode, or you risk causing a system overload.
 {% endhint %}
 
 ## View a configuration
@@ -46,4 +46,4 @@ From the configuration detail page, you can also:
 - **Download a sample JSON template** — Click the JSON icon in the toolbar to download a JSON template pre-populated with the parameter names expected by the import service.
 - **Upload a file** — Click `Upload File` to manually submit a CSV or JSON file for import.
 
-Once a file is done processing, its status will change to **Finished**. If processing finishes with error records, download the error file for review. Error files are in CSV or JSON format with error reasons attached to each record.
+Once a file is done processing, its status will change to **Finished**. If processing finishes with error records, download the error file for review. Error files are in CSV or JSON format with error reasons attached to each record

--- a/documents/system-admin/administration/data-manager/configuration-options.md
+++ b/documents/system-admin/administration/data-manager/configuration-options.md
@@ -1,57 +1,49 @@
 # Configuration options
 
-## Add or edit a configuration
+## Add a configuration
 
-If you're creating a new Import configuration to import data from an SFTP location
-1. Click the `Add` button
-2. Enter configuration details
-
-If you're editing an existing import or export configuration
-* Use the search bar to find the configuration by name or ID.
-* Click the `Edit` icon at the end of the search result.
+To create a new import configuration:
+1. Click the `Add` button on the Data Manager Configurations list page.
+2. Enter the configuration details in the dialog.
 
 {% hint style="info" %}
-The Config ID cannot be modified. To use a different ID, create a new configuration.
+The Config ID cannot be modified after creation. To use a different ID, create a new configuration.
 {% endhint %}
 
-| Field                 | Description                                             |
-| --------------------- | ------------------------------------------------------- |
-| **Config ID**         | Unique identifier for the configuration.                |
-| **Description**       | Short explanation of what the configuration handles.    |
-| **Import Service**    | Service name that handles incoming data.                |
-| **Import Path**       | SFTP Folder path for imported files.                    |
-| **Export Content ID** | Template identifier used while exporting data.          |
-| **Export Service**    | Service that handles outgoing data.                     |
-| **Export Path**       | SFTP Destination folder for exported files.             |
-| **File Name Pattern** | Identify and match only relevant files during processing using REGEX expressions |
-| **Multi-threading**   | Y/N flag to enable multi-threading on all files imported in this config (default N)|
-| **Execution Mode**    | Select from Sync, Async or Queued to set how the OMS prioritizes the processing of this configuration. (default Queued) |
-| **Notify on Failure** | Y/N flag to disable notifications on file import error (default Y)|
+## Edit a configuration
+To edit an existing configuration:
+* Use the search bar on the Data Manager Configurations list page to find the configuration by name or ID.
+* Click the configuration ID link to open its detail page.
+* Click the `Edit` button in the toolbar to open the edit dialog.
+
+### Configuration fields
+| Field                | Description                                                                                                         |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Config ID**        | Unique identifier for the configuration. Cannot be changed after creation.                                          |
+| **Description**      | Short explanation of what the configuration handles.                                                                |
+| **Import Service**   | Service name that handles incoming data.                                                                            |
+| **Execution Mode**   | How the OMS prioritizes processing. Select from `Queued`, `Sync`, or `Async`. Defaults to `Queued`.                |
+| **Multi-threading**  | Y/N flag to enable multi-threading for all files imported under this config. Defaults to `N`.                       |
+| **Priority**         | Numeric value that determines which thread pool handles this configuration. Higher values route to the Priority Pool.|
+| **Thread Pool**      | Read-only. Displays the worker pool (`PRIORITY` or `NORMAL`) assigned based on the Priority value.                 |
 
 {% hint style="danger" %}
-Execution mode should always be set to Queued
+Execution mode should always be set to Queued.
 {% endhint %}
 
 {% hint style="danger" %}
-Multi-threading should be disabled on all configs unless explicitly instructed by HotWax Support. Incorrect use of multi-threading can cause to system overload and downtime. If you've decided multi-threading is your poison, make sure that the configuration is set to execute in queued mode or else your almost certain to cause a system overload.
+Multi-threading should be disabled on all configs unless explicitly instructed by HotWax Support. Incorrect use of multi-threading can cause system overload and downtime. If multi-threading is enabled, ensure the configuration is set to execute in Queued mode, or you risk causing a system overload.
 {% endhint %}
 
-{% hint style="info"%} 
-Notifications are sent to the email addresses configured in the instances.
-{% endhint %}
+## View a configuration
+You may need to view a data manager configuration to manually import data or to audit data that has been imported by another user or a scheduled SFTP import job.
 
+1. On the Data Manager Configurations list page, click the **Config ID** link for the configuration you want to view.
+2. The configuration detail page opens, showing all configuration fields and a log of all imports for that configuration.
 
-### View a configuration
+From the configuration detail page, you can also:
+- **Download a sample CSV template** — Click the CSV icon in the toolbar to download a template file pre-populated with the column headers expected by the import service.
+- **Download a sample JSON template** — Click the JSON icon in the toolbar to download a JSON template pre-populated with the parameter names expected by the import service.
+- **Upload a file** — Click `Upload File` to manually submit a CSV or JSON file for import.
 
-You may need to view a data manager configuration to either manually import data or to audit data that has been imported either by another user or scheduled SFTP file import job.
-
-1. Click the `open link` icon beside the service name on the Data Manager Configuration search page.
-
-* This opens the [Import Data page](/documents/system-admin/administration/data-manager/manual-import.md) for the selected service.
-  
-2. Once a file is done processing, its status will change to **Finished**.
-
-   If processing finished with error records, download the error records for review. These are usually in JSON or CSV format, with error reasons attached to each record.
-
-3. Click the `Log` button to view detailed logs related to the service.
-4. Use the log to identify any specific failure or irregularity.
+Once a file is done processing, its status will change to **Finished**. If processing finishes with error records, download the error file for review. Error files are in CSV or JSON format with error reasons attached to each record.

--- a/documents/system-admin/administration/data-manager/configuration-options.md
+++ b/documents/system-admin/administration/data-manager/configuration-options.md
@@ -24,7 +24,7 @@ To edit an existing configuration:
 | **Import Service**   | Service name that handles incoming data.                                                                            |
 | **Execution Mode**   | How the OMS prioritizes processing. Select from `Queued`, `Sync`, or `Async`. Defaults to `Queued`.                |
 | **Multi-threading**  | Y/N flag to enable multi-threading for all files imported under this config. Defaults to `N`.                       |
-| **Priority**         | Numeric value that determines which thread pool handles this configuration. Higher values route to the Priority Pool.|
+| **Priority**         | Numeric value that determines which thread pool handles this configuration. Priorities greater than `6` route to the `PRIORITY` pool; `6` and below (and an empty value, which defaults to `5`) route to the `NORMAL` pool. |
 | **Thread Pool**      | Read-only. Displays the worker pool (`PRIORITY` or `NORMAL`) assigned based on the Priority value.                 |
 
 {% hint style="danger" %}

--- a/documents/system-admin/administration/data-manager/manual-import.md
+++ b/documents/system-admin/administration/data-manager/manual-import.md
@@ -1,11 +1,40 @@
 # Manual Imports
 
-## Importing Data in OMS
-1. Open a relevant import topic from the category based on your requirements. For instance, Procurement > Purchase Order.
-2. Download the provided sample CSV template.
-3. Once you've prepared a CSV or JSON file to import, click on `Choose File` to upload the file containing your data.
-4. The system will initiate the import, processing the provided data according to the chosen import topic.
+## Downloading a template
 
-If the file you uploaded does not begin processing immediately, the MDM you're using may be set to run in queued mode, which means it will be run by the queue polling job that runs at set intervals. In this case, to process the file immediately, go to the job manager app and run the Process Pending Bulk Imported Files job manually using the `Run Now` function.
+Before importing data, download the sample template for the configuration you want to use. Templates are pre-generated from the import service's expected parameters, so they always reflect the correct structure.
 
-After finishing its run, if the file terminates in a `Failed` status or produces `Error Records`, your data has not been processed and needs to be retried. To learn more about troubleshooting this, please refer to this document. (add link)
+From the configuration detail page, two template formats are available in the toolbar:
+
+- **CSV template** — Click the CSV icon to download a file with column headers formatted as hyphen-separated names (e.g., `product-id`, `facility-id`). Use this as your starting point when preparing a CSV import file.
+- **JSON template** — Click the JSON icon to download a JSON file with the expected parameter names as keys. Use this when the import service expects a JSON payload.
+
+## Importing data
+1. Navigate to the Data Manager Configurations list and open the relevant configuration by clicking its Config ID.
+2. From the configuration detail page, click `Upload File` in the toolbar.
+3. Select your prepared CSV or JSON file using the file chooser.
+4. Click `Add` to submit the file. The OMS will create a new log entry and begin processing.
+
+Once submitted, the import log entry will initially appear in `Pending` status. The MDM runner picks it up and routes it to either the Priority or Normal thread pool based on the configuration's priority setting.
+
+{% hint style="info" %}
+If the import does not begin processing immediately, the configuration may be set to Queued mode. The MDM runner processes queued imports at regular intervals. You can monitor the runner's last execution time and pool activity from the Find Import page.
+{% endhint %}
+
+## Monitoring the import
+After submitting, track progress from the log table on the configuration detail page:
+
+- **Status** updates from `Pending` → `Queued` → `Running` → `Finished` (or `Failed` / `Crashed` / `Cancelled`).
+- **Total Records** and **Failed Records** are updated as the import processes.
+- **Execution Time** shows the total time taken once the import completes.
+
+Click `View` in the **Parameters** column to inspect the exact parameters passed to the import service for that run.
+
+## Handling errors
+After the import finishes, if the status is `Failed` or the **Failed Records** count is greater than zero, your data has not been fully processed.
+
+1. Click the download icon in the **Error File** column to download the error records file.
+2. The file contains the original records along with an error reason for each failed row.
+3. Correct the identified errors in the file, remove the error reason column, and re-upload the corrected file.
+
+For detailed troubleshooting steps, refer to the [Audit Logs](/documents/system-admin/administration/data-manager/view-mdm-log.md) page.

--- a/documents/system-admin/administration/data-manager/view-mdm-log.md
+++ b/documents/system-admin/administration/data-manager/view-mdm-log.md
@@ -1,44 +1,67 @@
 # View Logs
 
-Data manager logs help verify the status of imported data, ensuring the accuracy and completeness of data imported into the OMS.
+Data Manager logs help verify the status of imported data, ensuring the accuracy and completeness of data imported into the OMS.
 
-Logs are located below the import function on all Data Manager detail pages.
+Logs are available in two places:
+- **Find Import page:** Shows all import logs across every configuration. Navigate here to get a system-wide view of all imports.
+- **Configuration detail page:** Shows import logs scoped to a single configuration. Navigate here when auditing imports for a specific config.
 
-In the result section, you will see the following columns
+## Log columns
+Each log entry displays the following columns:
 
-| Column         | Explanation                                                                                            |
-| -------------- | ------------------------------------------------------------------------------------------------------ |
-| Log Id         | A unique identifier for the transaction.                                                               |
-| User           | The user who performed the action.                                                                     |
-| Date           | The date and time the event occurred.                                                                  |
-| Uploaded File  | The CSV file that was uploaded.                                                                        |
-| View Log       | Provides detailed transaction logs for the entire event with timestamps.                               |
-| Failed Records | A CSV file containing records that failed to upload, along with error messages for each failed record. |
-| Status         | The status of the upload or download (Pending, Queued, Running, Finished, or Failed).                  |
-| Action         | Action to delete the record.                                                                           |
+| Column              | Description                                                                                                         |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Log ID**          | A unique identifier for the import log entry.                                                                       |
+| **Parent Log ID**   | If this import is a child of a parent import (e.g., a chunked sub-import), the parent's Log ID is shown here.      |
+| **Config ID**       | The configuration this import belongs to. Click to open the configuration detail page in a new tab.                 |
+| **Uploaded File**   | Download icon for the original file that was submitted. Also shows the file size in MB.                             |
+| **Import Parameters**      | Click `View` to open a dialog showing the key-value parameters passed to the import service for this run.           |
+| **Error File**      | Download icon for the error records file, if any records failed. Also shows the file size in MB.                    |
+| **Created Date**    | The date and time the import was submitted, along with the user who submitted it.                                   |
+| **Start Date**      | The date and time the import began processing.                                                                      |
+| **Status**          | The current status of the import. See [Statuses](#statuses) below.                                                  |
+| **Completion Date** | The date and time the import finished, was cancelled, or crashed — shown alongside the Status column.               |
+| **Product Store**   | The product store associated with this import, if applicable.                                                       |
+| **Total Records**   | The total number of records in the submitted file.                                                                  |
+| **Failed Records**  | The number of records that failed to process. Shown in red.                                                         |
+| **Execution Time**  | The total time taken to process the file, computed from start to finish (or cancellation).                          |
+
+{% hint style="info" %}
+On the Configuration detail page, a **Run Thread** column is also displayed, showing the worker thread that processed the import.
+{% endhint %}
 
 ## Statuses
+Each import progresses through the following statuses:
 
-Understand the different status types in the data logs:
+| Status        | Description                                                                                          |
+| ------------- | ---------------------------------------------------------------------------------------------------- |
+| **Pending**   | The file has been submitted and is waiting to be picked up by the MDM runner.                        |
+| **Queued**    | The MDM runner has picked up the file and placed it in the worker pool queue.                        |
+| **Running**   | The file is actively being processed by a worker thread.                                             |
+| **Finished**  | Processing completed successfully.                                                                   |
+| **Failed**    | Processing completed but encountered a failure. Check the Error File for details.                    |
+| **Crashed**   | The runner or worker thread terminated unexpectedly during processing.                               |
+| **Cancelled** | The import was manually cancelled by a user.                                                         |
 
-| Status   | Description                              |
-| -------- | ---------------------------------------- |
-| Pending  | Transaction is yet to be initiated.      |
-| Running  | Download or Import is getting processed. |
-| Finished | Transaction success.                     |
-| Failed   | Transaction has failed.                  |
+## Actions
+### Cancel an import
+A `Pending` import can be cancelled before the MDM runner picks it up. Click the **X** button on the log entry to cancel it. Once an import moves to `Queued` or `Running` status, it can no longer be cancelled this way.
 
+### Delete a log entry
+Click the **trash** icon on a log entry to permanently delete the import record. This removes the log entry and any associated uploaded or error files from the system.
+
+## Troubleshooting
 **File Upload Failed:**
 
-This typically occurs when the file format does not align with the required CSV format. To resolve this, convert the file to CSV format before attempting to upload it again.
+This typically occurs when the file format does not align with the required CSV or JSON format. Download the sample template from the configuration detail page and ensure your file matches the expected structure before re-uploading.
 
 **File upload is partially failed:**
 
-Failed records are generated when a file is successfully processed, but discrepancies in the uploaded data lead to some records failing. In these scenarios, the record with correct data gets processed and a file containing all failed records with invalid data becomes available in the Failed Records section. You'll find a failed records file associated with such cases in the logs. By examining this file, you can easily identify and comprehend data errors in the uploaded file. Details about the errors in the records are available in the failed records file, providing clarity on what went wrong. After addressing the identified errors, you can confidently reupload the failed record file after removing the error reason column without encountering further issues. Some of the possible error types are as follows:
+Failed records are generated when a file is successfully processed, but discrepancies in the uploaded data cause some records to fail. The records with correct data get processed, and a file containing all failed records with error details becomes available in the **Error File** column. Download the error file to identify what went wrong for each record. After fixing the errors, re-upload the corrected file. Some possible error types are:
 
-| Error Type     | Description                                             |
-| -------------- | ------------------------------------------------------- |
-| Invalid Data   | Data that does not conform to expected values.          |
-| Invalid Format | Correct type but doesn't follow the expected structure. |
-| Missing Field  | A required field is not provided or is empty.           |
-| Required Field | A field marked as required is left blank.               |
+| Error Type       | Description                                             |
+| ---------------- | ------------------------------------------------------- |
+| **Invalid Data** | Data that does not conform to expected values.          |
+| **Invalid Format**| Correct type but doesn't follow the expected structure.|
+| **Missing Field**| A required field is not provided or is empty.           |
+| **Required Field**| A field marked as required is left blank.              |

--- a/documents/system-admin/administration/data-manager/view-mdm-log.md
+++ b/documents/system-admin/administration/data-manager/view-mdm-log.md
@@ -1,6 +1,6 @@
 # View Logs
 
-Data Manager logs help verify the status of imported data, ensuring the accuracy and completeness of data imported into the OMS.
+Data Manager logs help verify the status, accuracy, and completeness of data imported into the OMS.
 
 Logs are available in two places:
 - **Find Import page:** Shows all import logs across every configuration. Navigate here to get a system-wide view of all imports.
@@ -20,7 +20,7 @@ Each log entry displays the following columns:
 | **Created Date**    | The date and time the import was submitted, along with the user who submitted it.                                   |
 | **Start Date**      | The date and time the import began processing.                                                                      |
 | **Status**          | The current status of the import. See [Statuses](#statuses) below.                                                  |
-| **Completion Date** | The date and time the import finished, was cancelled, or crashed — shown alongside the Status column.               |
+| **Completion Date** | The date and time the import finished, was cancelled, or crashed. Shown alongside the Status column.                |
 | **Product Store**   | The product store associated with this import, if applicable.                                                       |
 | **Total Records**   | The total number of records in the submitted file.                                                                  |
 | **Failed Records**  | The number of records that failed to process. Shown in red.                                                         |
@@ -53,7 +53,7 @@ Click the **trash** icon on a log entry to permanently delete the import record.
 ## Troubleshooting
 **File Upload Failed:**
 
-This typically occurs when the file format does not align with the required CSV or JSON format. Download the sample template from the configuration detail page and ensure your file matches the expected structure before re-uploading.
+This typically occurs when the file format does not align with the required CSV or JSON format. Download the sample template from the configuration detail page and verify that your file matches the expected structure before re-uploading.
 
 **File upload is partially failed:**
 


### PR DESCRIPTION
Updated Data Manager documentation to align with the new Maarg (Moqui-based) implementation.

_Changes_:
README.md — Added dual thread pool (Priority/Normal) architecture, 7 import statuses, and file storage & retention details.

configuration-options.md — Removed deprecated OFBiz fields; added new Priority and Thread Pool fields.

manual-import.md — Added CSV/JSON template download feature and updated upload workflow.

view-mdm-log.md — Updated log columns, Import Parameters dialog, and Cancel/Delete actions.

Resolves #1732 