### PR TITLE
Refresh Order Manager documentation

### DIFF
--- a/documents/retail-operations/orders/order-management/README.md
+++ b/documents/retail-operations/orders/order-management/README.md
@@ -6,7 +6,7 @@ description: >-
 
 # Order management
 
-Use Order Manager to monitor order flow and act on orders that need attention. The app opens on the **Funnel** page and includes dedicated queues for blocked and in-progress orders.
+Use Order Manager to monitor order flow and act on orders that need attention. The app opens on the `Funnel` page and includes dedicated queues for blocked and in-progress orders.
 
 <table data-view="cards"><thead><tr><th></th><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><strong>Funnel</strong></td><td>Review order volume, brokering progress, picked and packed progress, hold tasks, and facility performance.</td><td><a href="#funnel">Funnel</a></td></tr><tr><td><strong>Find order</strong></td><td>Search orders by order, external ID, customer, email, status, date, and channel.</td><td><a href="find-sales-orders.md">Find sales orders</a></td></tr><tr><td><strong>Find customers</strong></td><td>Search customers and open customer detail records when an order issue needs customer context.</td><td><a href="#find-customers">Find customers</a></td></tr><tr><td><strong>Blocked queues</strong></td><td>Work unfillable, bad address, fraud, and hold queues.</td><td><a href="#blocked-queues">Blocked queues</a></td></tr><tr><td><strong>In-progress queues</strong></td><td>Review open, inflight, and packed orders.</td><td><a href="#in-progress-queues">In-progress queues</a></td></tr><tr><td><strong>Settings</strong></td><td>Confirm app settings before working order queues.</td><td><a href="#settings">Settings</a></td></tr></tbody></table>
 
@@ -16,18 +16,18 @@ The Funnel page is the operational starting point for Order Manager. Use it to u
 
 The Funnel page includes:
 
-* Product store selection.
-* Today order count.
-* Brokering status.
-* Picked and packed progress.
-* Open order count.
-* Unfillable order count.
-* Order hold task counts for substitute, bad address, and fraud work.
-* Facility-level order volume and fulfillment metrics.
+* Product store selection
+* Today order count
+* Brokering status
+* Picked and packed progress
+* Open order count
+* Unfillable order count
+* Order hold task counts for substitute, bad address, and fraud work
+* Facility-level order volume and fulfillment metrics
 
 ## Find customers
 
-Use **Find customers** when an order issue needs customer context. Customer detail pages keep customer lookup separate from order lookup so support users can find contact and customer history without starting from an order ID.
+Use `Find customers` when an order issue needs customer context. Customer detail pages keep customer lookup separate from order lookup so support users can find contact and customer history without starting from an order ID.
 
 ## Blocked queues
 
@@ -52,7 +52,7 @@ In-progress queues show orders that are moving through fulfillment.
 
 ## Settings
 
-Use **Settings** to confirm app configuration before working order queues. If order counts or queue results look wrong, confirm the current product store and OMS context before troubleshooting the order data.
+Use `Settings` to confirm app configuration before working order queues. If order counts or queue results look wrong, confirm the current product store and OMS context before troubleshooting the order data.
 
 ## Screenshot gaps
 

--- a/documents/retail-operations/orders/order-management/README.md
+++ b/documents/retail-operations/orders/order-management/README.md
@@ -1,9 +1,59 @@
 ---
 description: >-
-  Checkout workflows involved in Order Management. Gaining an understanding of
-  these processes will give you an overview of how orders are handled from start
-  to end.
+  Use Order Manager to search orders, review the order funnel, work blocked
+  order queues, and inspect customer and order details.
 ---
 
 # Order management
 
+Use Order Manager to monitor order flow and act on orders that need attention. The app opens on the **Funnel** page and includes dedicated queues for blocked and in-progress orders.
+
+<table data-view="cards"><thead><tr><th></th><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><strong>Funnel</strong></td><td>Review order volume, brokering progress, picked and packed progress, hold tasks, and facility performance.</td><td><a href="#funnel">Funnel</a></td></tr><tr><td><strong>Find order</strong></td><td>Search orders by order, external ID, customer, email, status, date, and channel.</td><td><a href="find-sales-orders.md">Find sales orders</a></td></tr><tr><td><strong>Find customers</strong></td><td>Search customers and open customer detail records when an order issue needs customer context.</td><td><a href="#find-customers">Find customers</a></td></tr><tr><td><strong>Blocked queues</strong></td><td>Work unfillable, bad address, fraud, and hold queues.</td><td><a href="#blocked-queues">Blocked queues</a></td></tr><tr><td><strong>In-progress queues</strong></td><td>Review open, inflight, and packed orders.</td><td><a href="#in-progress-queues">In-progress queues</a></td></tr><tr><td><strong>Settings</strong></td><td>Confirm app settings before working order queues.</td><td><a href="#settings">Settings</a></td></tr></tbody></table>
+
+## Funnel
+
+The Funnel page is the operational starting point for Order Manager. Use it to understand how many orders entered today, how far orders have progressed through brokering and packing, and which exception queues need attention.
+
+The Funnel page includes:
+
+* Product store selection.
+* Today order count.
+* Brokering status.
+* Picked and packed progress.
+* Open order count.
+* Unfillable order count.
+* Order hold task counts for substitute, bad address, and fraud work.
+* Facility-level order volume and fulfillment metrics.
+
+## Find customers
+
+Use **Find customers** when an order issue needs customer context. Customer detail pages keep customer lookup separate from order lookup so support users can find contact and customer history without starting from an order ID.
+
+## Blocked queues
+
+Blocked queues group orders that need review before they can continue.
+
+| Queue | Use it when |
+| --- | --- |
+| Unfillable | An order or item cannot be fulfilled from current inventory or routing results. |
+| Bad address | The shipping address needs correction before fulfillment can continue. |
+| Fraud | The order needs fraud review before release. |
+| Hold | The order has a hold task or manual review requirement. |
+
+## In-progress queues
+
+In-progress queues show orders that are moving through fulfillment.
+
+| Queue | Use it when |
+| --- | --- |
+| Open | Orders are ready for fulfillment work. |
+| Inflight | Orders are already moving through the fulfillment process. |
+| Packed | Orders have been picked and packed and are ready for the next fulfillment step. |
+
+## Settings
+
+Use **Settings** to confirm app configuration before working order queues. If order counts or queue results look wrong, confirm the current product store and OMS context before troubleshooting the order data.
+
+## Screenshot gaps
+
+This section needs updated screenshots from a clean test OMS. Capture the Funnel page with realistic order counts, queue cards, and facility names. Avoid screenshots that show placeholder numbers, private customer data, empty queues, browser chrome, or internal comments.

--- a/documents/retail-operations/orders/order-management/find-sales-orders.md
+++ b/documents/retail-operations/orders/order-management/find-sales-orders.md
@@ -1,69 +1,46 @@
-# Find Sales Orders
+# Find orders
 
-The `Find Sales Order` page in HotWax Commerce offers users a comprehensive listing of all orders, accompanied by essential order details including order items, order ID, order date, and customer information. Additionally, users can easily ascertain the current status of each order and identify the facility to which it is allocated. For enhanced order management, the page also displays promise dates and auto-cancel dates, ensuring timely fulfillment.
+Use **Find order** to search the order index and open order detail records. The page supports direct lookup and filtered search for support, operations, and merchandising users who need to find a specific order or work a list of orders.
 
-To streamline the search process, users have the option to search for orders using product identifiers on the search page. Moreover, filters such as product store, facility, and sales channel are available to further refine and manage the order list.
+## Search orders
 
-For seamless integration with external systems, users can export order data in CSV format, facilitating efficient order fulfillment processes across platforms.
+The search field accepts order identifiers, external IDs, customer names, and customer email addresses.
 
-**HotWax Commerce offers the following features on the Sales Order Page:**
+To search for an order:
 
-### Search Sales Orders
+1. Open **Order Manager** > **Find order**.
+2. Enter an order, external ID, customer name, or email address.
+3. Use filters when the search returns too many results.
+4. Select an order row to open the order details page.
 
-The `Search Sales Order` feature on the `Sales Order` page provides users with quick access to information regarding a specific Order Information. Users can search for Orders based on various identifiers such as Order ID, Customer name, SKU, etc. to get an instant overview of the order.
+## Filter orders
 
-**Step-by-Step Usage Instructions:**
+Use filters to narrow the order list before opening an order or selecting multiple orders.
 
-1. Navigate to the HotWax Commerce platform and log in with your credentials. The first page that opens up upon logging in is the Sales Order page.
-2. Within the `Sales Order Page`, you'll find a search bar.
-3. In the search bar, you can enter the identifier of the desired order you wish to locate.
-4. Press the `Enter` key to initiate the search process after entering the search criteria.
-5. The platform will display the search results based on the provided SKU or order ID.
-6. You can now view all pertinent details related to the order, including customer information, order items, and status. Click on the order to access the detailed information.
+| Filter | Use it to |
+| --- | --- |
+| Status | Show all statuses or one or more order statuses. |
+| Order date from | Start the search at a specific order date. |
+| Order date thru | End the search at a specific order date. |
+| Channel | Limit results to one sales channel. |
+| Sort by order date | Show newest orders first or oldest orders first. |
 
-{% embed url="https://youtu.be/g3h3HX6YNNY" %}
+The results list shows the order name or external ID, HotWax order ID, customer name or customer ID, order date, ship time, and order status.
 
-### Filter Orders
+## Select orders
 
-HotWax Commerce allows users to sort through numerous orders based on different filter criteria. Enabling users to focus on specific subsets of orders, making it particularly valuable for those dealing with high order volume.
+Use **Select** when you need to prepare bulk action work from the current result set. After selecting orders, the footer shows the selected count and available bulk actions.
 
-You can apply these filters to Sales Orders:
+Available actions include:
 
-| Filter Name      | Description                                                                                                             |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| Product Store    | Choose the desired Product Store from the dropdown menu to filter by a specific store.                                  |
-| Facility         | Select the Facility to narrow down the results to a particular location.                                                |
-| Order Status     | Filter by Order Status to view orders in a specific stage (created, approved, completed, canceled).                     |
-| Item Status      | Filter by Item Status to focus on specific stages of item fulfillment (Reserved, Picking, Packing, Shipped, Delivered). |
-| Sales Channel    | Choose the desired Sales channel from the dropdown menu to filter by a specific channel such as Shopify, Amazon, etc.   |
-| Order Date       | This filter categorizes orders based on their order date, allowing users to filter them by predefined time intervals.   |
-| Promised Date    | This filter categorizes orders based on their promise date, allowing users to filter them by predefined time intervals. |
-| Auto Cancel Date | The auto-cancel date is the predetermined deadline by which an order will be automatically canceled if not fulfilled.   |
-| Shipping Method  | Filter by the shipping method such as delivery speed (standard, expedited, express), cost, or specific carriers.        |
+* Cancel open items
+* Edit shipping method
+* Add task
 
-{% hint style="success" %}
-You can save the search filters using the disc icon and view the saved search filter by clicking on the three horizontal eclipses on the right.
+{% hint style="info" %}
+Bulk action buttons may be disabled until at least one order is selected.
 {% endhint %}
 
-{% embed url="https://youtu.be/eMb3WC2JmBI" %}
+## Screenshot gaps
 
-### Filter Orders based on Queue
-
-HotWax Commerce has different queues that act as a virtual facility to park the orders that are awaiting fulfillment. Users can view the orders in the queue to identify orders that currently do not have inventory allocated to them.
-
-| Queue Name      | Description                                                                                                                                                                     |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Pre-Orders      | Orders that are placed in Pre-order parking (To hold pre-ordered items until released from HC) can be shown by clicking on the Pre-orders checkbox.                             |
-| Back Orders     | Orders that are placed in Backorder parking (To hold back-ordered items until released from the HC) can be shown by clicking on the Back-orders checkbox.                       |
-| Brokering Queue | Orders that are placed in the Brokering Queue (To hold orders for in-stock items until the next brokering run) can be shown by clicking on the Brokering Queue checkbox.        |
-| Unfillable Hold | Orders that are placed in the Unfillable Hold (To hold unfillable items from further brokering and auto-cancellation) can be shown by clicking on the Unfillable Hold checkbox. |
-
-By filtering orders based on queues, users can focus on handling orders that require immediate attention or fall into the queue.
-
-Users can also filter the orders that will be auto-canceled today to make sure such orders are prioritized.
-
-{% embed url="https://youtu.be/_UYtNXq4IiA" %}
-
-### Export Orders
-
-Enables users to export all displayed sales orders into CSV using the Export CSV function. Once the filtered orders are displayed, Click on the `Export CSV` option to initiate the export process.
+This page needs updated screenshots from test OMS showing realistic order IDs, customer names, order dates, and statuses. Use a filtered list with enough results to show the page structure, but avoid real customer contact details.

--- a/documents/retail-operations/orders/order-management/find-sales-orders.md
+++ b/documents/retail-operations/orders/order-management/find-sales-orders.md
@@ -1,6 +1,6 @@
 # Find orders
 
-Use **Find order** to search the order index and open order detail records. The page supports direct lookup and filtered search for support, operations, and merchandising users who need to find a specific order or work a list of orders.
+Use `Find order` to search the order index and open order detail records. The page supports direct lookup and filtered search for support, operations, and merchandising users who need to find a specific order or work a list of orders.
 
 ## Search orders
 
@@ -8,7 +8,7 @@ The search field accepts order identifiers, external IDs, customer names, and cu
 
 To search for an order:
 
-1. Open **Order Manager** > **Find order**.
+1. Open **Order Manager** > `Find order`.
 2. Enter an order, external ID, customer name, or email address.
 3. Use filters when the search returns too many results.
 4. Select an order row to open the order details page.
@@ -29,7 +29,7 @@ The results list shows the order name or external ID, HotWax order ID, customer 
 
 ## Select orders
 
-Use **Select** when you need to prepare bulk action work from the current result set. After selecting orders, the footer shows the selected count and available bulk actions.
+Use `Select` when you need to prepare bulk action work from the current result set. After selecting orders, the footer shows the selected count and available bulk actions.
 
 Available actions include:
 

--- a/documents/retail-operations/orders/order-management/view-order-details.md
+++ b/documents/retail-operations/orders/order-management/view-order-details.md
@@ -1,76 +1,44 @@
-# View Order Details
+# View order details
 
-The comprehensive `Order View Page` within HotWax Commerce enhances user efficiency and facilitates streamlined order management. This page consolidates all essential information related to an order, providing users with a holistic view that encompasses key details such as billing and shipping information, order identification, payment terms, preferences, timelines, references, communications, and a detailed list of items. To access the `order view page`, simply click on the order ID on the `find sales order` page to view comprehensive details about the order.
+Use the order details page to inspect one order, review its timeline, confirm customer and payment information, and act on items, ship groups, holds, and communications.
 
-HotWax Commerce offers the following features on the `Order View Page`:
+Open an order from **Find order** or one of the Order Manager queues.
 
-### Overview Section
+## Header
 
-The overview section contains essential information related to billing and order processing. Here's a summary of each element:
+The header shows the order name, HotWax order ID, and current order status. A timeline appears below the header so you can review status changes and facility changes without leaving the page.
 
-1. **Bill To (To-Customer):** Indicates the customer who will be billed for the order.
-2. **Bill From (Company, Channel, Product Store):** Specifies the origin details, including the company, sales channel, and product store associated with the transaction.
-3. **Status:** Reflects the current status of the order, providing insights into its progress or completion.
-4. **Order Date:** Records the date when the order was placed or initiated.
-5. **External ID:** Identifier for external system.
-6. **Subtotal:** Displays the total cost of items or services before additional adjustments.
-7. **Total:** The overall cost of the order, which can be manually adjusted for discounts, promotions, replacements, and taxes.
+## Detail cards
 
-This information provides a comprehensive overview of an order, facilitating effective management and customization of billing details.
+The order detail cards summarize the order context.
 
-### Order Identifications
+| Card | Shows |
+| --- | --- |
+| Customer | Customer name, email, phone, and billing address. |
+| Order identifications | Order name, external ID, HotWax order ID, and additional order identifiers. |
+| Order payment preference | Payment method, amount, and payment status. |
+| Source | Product store and sales channel. |
 
-The `Order Identifications` section displays key information related to Shopify orders. The four main components of this section are:
+## Items
 
-1. **Shopify Order ID:**
-   * This is a unique identifier assigned by Shopify to each order. It serves as a reference point for tracking and managing orders within the Shopify platform. Additionally, users can conveniently view the order details directly on Shopify by clicking on the provided link associated with the Shopify order ID.
-2. **Shopify Order Name:**
-   * The order name in Shopify typically refers to a customizable name or title assigned to an order on Shopify for further order identification.
-3. **Shopify Order Number:**
-   * Shopify assigns a distinct numerical identifier to each order. It acts as another unique reference for orders, often used in communication and documentation.
-4. **Order Attributes:**
-   * Shopify retailers can capture additional crucial order details through metafields. Once customer IDs are verified, they are stored as order metafields in Shopify. When HotWax Commerce enters a retailer’s Shopify ecosystem, it becomes the source of truth for all order-related information. HotWax Commerce downloads order details along with customers’ IDs as order attributes and shares this information with the retailer's accounting system. All downloaded order attributes are visible under this section.
-   * Users can also add Order Attributes by clicking the `Add Order Attribute +` button which will open up a new form. Add the attribute name, value and description and click on the Add button to save the order attribute. This function is vital if there are some issue in importing order attributes such as metafield being added after the order has been imported in HotWax Commerce.
+Use the **Items** segment to review order items. Items are grouped by product so users can see quantity, status, price, product image, SKU, and external ID together.
 
-### Payment Section
+You can select all items or select individual item groups when preparing item-level actions. Use **Add items** when the workflow requires an order item to be added manually.
 
-In the Payments Section, users can easily view the payment method and total payment value made by customers on the e-commerce platform. This data is then transmitted to the ERP system. Particularly for cash on delivery orders, this information is vital as store associates need to collect payment during fulfillment.
+## Ship groups
 
-### Order Timeline
+Use the **Ship groups** segment to review fulfillment group information. Ship groups are the operational split between items, facilities, shipment details, and fulfillment progress.
 
-The timeline illustrates the progression of events from the initial order decision to the completion of the transaction, including the involvement of a broker as an intermediary. Here's a brief description of each term:
+## Holds
 
-1. **Order Date:**
-   * The date and time when the customer made a purchase.
-2. **Entry Date:**
-   * The date and time when the order information was officially recorded into HotWax Commerce.
-3. **First Brokered:**
-   * The first brokered refers to the initial timestamp when an item is allocated to a specific facility. This timestamp remains unchanged even if the item is subsequently rejected by the facility and redirected elsewhere. It serves as a fixed reference point for tracking the item's movement history within the system.
-4. **Completed Date:**
-   * The date and time when the order was fulfilled, and the goods or services were delivered or made available to the buyer.
+Use the **Holds** segment to review hold work associated with the order. Holds are useful when an order is blocked by address review, fraud review, substitute review, inventory unavailability, or another manual task.
 
-**For Example:**
+## Communications
 
-| Event          | Date and Time       |
-| -------------- | ------------------- |
-| Order Date     | 03-08-2024 06:07 PM |
-| Entry Date     | 03-08-2024 06:13 PM |
-| First Brokered | 03-09-2024 01:00 AM |
-| Completed Date | 03-11-2024 03:16 PM |
+Use the **Comms** segment to review or add communication records for the order. Communications help support and operations teams keep customer-facing updates and internal notes attached to the order.
 
-### References
+<figure><img src="../../.gitbook/assets/sales-order-view-details.png" alt="Order details page showing order header, customer information, order identifiers, payment details, and source information"><figcaption><p>Order details</p></figcaption></figure>
 
-In the HotWax Commerce platform, the `Reference Section` offers a centralized hub for users to access critical information related to picklist status, packing details, shipment information, and returns details. This feature provides quick and easy access to essential data. Users can click on the relevant item such as return ID, picklist ID, etc. to access the order details. Users can see the following details in this section:
+## Screenshot gaps
 
-* Click on the `Picklist Status` link to view the current status of picklists associated with orders.
-* Click on the `Packing Details` link to view information regarding the packing process for orders. This includes details such as items packed, and any special instructions.
-* Click on the `Shipment Information` link to access data related to order shipments. This may include tracking numbers, carrier information, and expected delivery dates.
-* Click on the `Returns Details` section to review information about product returns initiated by customers for this order and the status of the return.
-
-### Communications
-
-The `Communications` feature in the HotWax Commerce platform acts as a central hub for users to interact with both the internal team and customers, providing updates on orders. With the capability to add notes and send personalized emails directly from this interface, users can efficiently communicate important updates or notifications to internal teams or customers. Whether it's informing customers about order changes, cancellations, or backorder notifications, or adding notes for the fulfillment team, this feature simplifies communication processes, minimizing misunderstandings and improving overall order management efficiency.
-
-Click on the communication and select either email or notes to start the communication.
-
-<figure><img src="../../.gitbook/assets/sales-order-view-details.png" alt=""><figcaption></figcaption></figure>
+The screenshot on this page should be replaced with a current Order Manager screenshot from test OMS. Use an order with realistic products, statuses, ship groups, payments, and customer data that is safe for documentation.

--- a/documents/retail-operations/orders/order-management/view-order-details.md
+++ b/documents/retail-operations/orders/order-management/view-order-details.md
@@ -2,7 +2,7 @@
 
 Use the order details page to inspect one order, review its timeline, confirm customer and payment information, and act on items, ship groups, holds, and communications.
 
-Open an order from **Find order** or one of the Order Manager queues.
+Open an order from `Find order` or one of the Order Manager queues.
 
 ## Header
 
@@ -21,21 +21,21 @@ The order detail cards summarize the order context.
 
 ## Items
 
-Use the **Items** segment to review order items. Items are grouped by product so users can see quantity, status, price, product image, SKU, and external ID together.
+Use the `Items` segment to review order items. Items are grouped by product so users can see quantity, status, price, product image, SKU, and external ID together.
 
-You can select all items or select individual item groups when preparing item-level actions. Use **Add items** when the workflow requires an order item to be added manually.
+You can select all items or select individual item groups when preparing item-level actions. Use `Add items` when the workflow requires an order item to be added manually.
 
 ## Ship groups
 
-Use the **Ship groups** segment to review fulfillment group information. Ship groups are the operational split between items, facilities, shipment details, and fulfillment progress.
+Use the `Ship groups` segment to review fulfillment group information. Ship groups are the operational split between items, facilities, shipment details, and fulfillment progress.
 
 ## Holds
 
-Use the **Holds** segment to review hold work associated with the order. Holds are useful when an order is blocked by address review, fraud review, substitute review, inventory unavailability, or another manual task.
+Use the `Holds` segment to review hold work associated with the order. Holds are useful when an order is blocked by address review, fraud review, substitute review, inventory unavailability, or another manual task.
 
 ## Communications
 
-Use the **Comms** segment to review or add communication records for the order. Communications help support and operations teams keep customer-facing updates and internal notes attached to the order.
+Use the `Comms` segment to review or add communication records for the order. Communications help support and operations teams keep customer-facing updates and internal notes attached to the order.
 
 <figure><img src="../../.gitbook/assets/sales-order-view-details.png" alt="Order details page showing order header, customer information, order identifiers, payment details, and source information"><figcaption><p>Order details</p></figcaption></figure>
 


### PR DESCRIPTION
## Problem
Order Manager documentation still described the older Sales Order page as the default experience. The current app opens on the Funnel page and includes Find order, Find customers, blocked queues, in-progress queues, and Settings.

## Pages changed
- documents/retail-operations/orders/order-management/README.md
- documents/retail-operations/orders/order-management/find-sales-orders.md
- documents/retail-operations/orders/order-management/view-order-details.md

## What changed
- Updated the section overview around the current Order Manager menu and queue model.
- Rewrote Find order around the current search filters and select-mode footer.
- Rewrote View order details around current header cards and Items, Ship groups, Holds, and Comms segments.
- Added GitBook cards and explicit screenshot gaps for Test OMS capture.
- Added descriptive alt text for the retained order details image.

## Validation
- Verified current app routes and menu against local code in apps/order-manager.
- Checked local anchors in GitBook cards.
- Checked changed files for empty alt text, empty links, Hotwax casing, UK fulfilment spelling, and banned style-guide terms.

## Evidence
- Code reference: /Users/adityapatel/Documents/github/apps/order-manager/src/router/index.ts
- Code reference: /Users/adityapatel/Documents/github/apps/order-manager/src/components/Menu.vue
- Code reference: /Users/adityapatel/Documents/github/apps/order-manager/src/views/Funnel.vue
- Code reference: /Users/adityapatel/Documents/github/apps/order-manager/src/views/OrderSearch.vue
- Code reference: /Users/adityapatel/Documents/github/apps/order-manager/src/views/OrderDetail.vue

Closes #1763