### PR TITLE
Add Products app User manual

### DIFF
--- a/documents/store-operations/products/duplicate-identifier.md
+++ b/documents/store-operations/products/duplicate-identifier.md
@@ -1,0 +1,24 @@
+# Duplicate Identifiers
+
+The `Duplicate Identifiers` page helps users find and resolve products that share the same `SKU` or `UPC`, both of which should be unique per product or variant. The page is organized into two tabs:
+
+* **SKU**: Each product should have a unique SKU. Resolve a group by giving each product a unique value, then save.
+* **UPC**: Each variant should have a unique UPC. Resolve a group by giving each product a unique value, then save.
+
+If no duplicates exist for the selected identifier, the page displays `No duplicates` along with the message `Every product has a unique SKU` (or `UPC`, depending on the active tab).
+
+When duplicates are found, the page displays the total number of duplicate groups (for example: `8 duplicate groups`), followed by a list of groups. Each group shows:
+
+* The shared identifier value causing the duplication (for example: `pollo-s`).
+* A `RESOLVE [N] PRODUCTS` button, where `[N]` is the number of products sharing that value.
+
+## Resolving a Duplicate Group
+
+**Step-by-Step Usage Instructions:**
+
+1. On the `Duplicate Identifiers` page, select the `SKU` or `UPC` tab depending on which identifier needs resolving.
+2. Find the duplicate group to resolve and click `RESOLVE [N] PRODUCTS`. This opens the `Resolve SKU`/`Resolve UPC` modal.
+3. The modal lists every product in the group, each showing its variant name, `Product ID`, and an editable field pre-filled with the current duplicate value. Each product also shows a status, either `Unchanged` or, once edited, `Was [original value]`, reflecting the value it had before editing.
+4. Update the value in the field for each product that needs a unique identifier.
+5. As changes are made, the `SAVE [N] CHANGES` button at the bottom of the modal updates to reflect the number of edited products, and becomes active.
+6. Click `SAVE [N] CHANGES` to apply the updates, or `CLOSE` to exit the modal without saving.

--- a/documents/store-operations/products/duplicate-identifier.md
+++ b/documents/store-operations/products/duplicate-identifier.md
@@ -14,7 +14,7 @@ When duplicates are found, the page displays the total number of duplicate group
 
 ## Resolving a Duplicate Group
 
-**Step-by-Step Usage Instructions:**
+Step-by-step usage instructions:
 
 1. On the `Duplicate Identifiers` page, select the `SKU` or `UPC` tab depending on which identifier needs resolving.
 2. Find the duplicate group to resolve and click `RESOLVE [N] PRODUCTS`. This opens the `Resolve SKU`/`Resolve UPC` modal.

--- a/documents/store-operations/products/imports.md
+++ b/documents/store-operations/products/imports.md
@@ -1,0 +1,25 @@
+# Imports
+
+The `Imports` page shows a running log of product data synced into HotWax Commerce from connected sales channels, such as Shopify, so users can confirm that updates are coming through correctly. The page displays the `Last 100 recently synced product updates`.
+
+### Search Imports
+
+The search bar lets users search the synced records by product, `SKU`, barcode, or shop.
+
+### Refresh
+
+Click `REFRESH`, on the top right of the page, to reload the list with the latest synced records.
+
+### Synced Records List
+
+Each entry in the list represents a single product or variant update received from a sales channel, and shows:
+
+| **Field**        | **Description**                                                                                   |
+| ------------------ | -------------------------------------------------------------------------------------------------- |
+| Identifier          | The product or variant ID from the source sales channel.                                          |
+| Parent              | The source channel's ID for the parent product. Shown only when the entry is for a variant.        |
+| System Message      | The corresponding HotWax Commerce `Product ID` the synced record was mapped to.                    |
+| Status               | Whether the update was applied successfully, shown as `Synced`.                                    |
+| Shop                 | The ID of the shop the update was synced from.                                                      |
+| Timestamp            | The date and time the update was synced.                                                            |
+

--- a/documents/store-operations/products/missing-values.md
+++ b/documents/store-operations/products/missing-values.md
@@ -4,9 +4,9 @@ The `Missing Values` page provides a centralized dashboard representing informat
 
 ### Catalog Coverage
 
-The `Catalog coverage` cards displays key product identifiers and attributes, such as `Brand`, `Tags`, `SKU`, and others, along with a real-time count of how many items are missing that specific marker, in a worst-first fashion.
+The `Catalog coverage` cards display key product identifiers and attributes, such as `Brand`, `Tags`, `SKU`, and others, along with a real-time count of how many items are missing that specific marker, in a worst-first fashion.
 
-The `Catalog coverage` cards consists of the following attributes and identifiers:
+The `Catalog coverage` cards consist of the following attributes and identifiers:
 
 | **Attribute**         | **Description**                                                                  |
 | ------------------- | ------------------------------------------------------------------------------------ |

--- a/documents/store-operations/products/missing-values.md
+++ b/documents/store-operations/products/missing-values.md
@@ -1,0 +1,36 @@
+# Missing Values
+
+The `Missing Values` page provides a centralized dashboard representing information about products with missing information. It scans the product catalog to identify gaps and missing attributes, and provides the necessary tools to fill in these gaps.
+
+### Catalog Coverage
+
+The `Catalog coverage` cards displays key product identifiers and attributes, such as `Brand`, `Tags`, `SKU`, and others, along with a real-time count of how many items are missing that specific marker, in a worst-first fashion.
+
+The `Catalog coverage` cards consists of the following attributes and identifiers:
+
+| **Attribute**         | **Description**                                                                  |
+| ------------------- | ------------------------------------------------------------------------------------ |
+| Brand               | The brand the product is associated with.                                          |
+| Image               | The primary image used to visually represent the product.                          |
+| Tags                | Labels applied to the product for grouping, filtering, or bulk actions.            |
+| UPC                 | The Universal Product Code assigned to a variant.                                   |
+| SKU                 | The Stock Keeping Unit used to track a variant internally and across systems.        |
+| Primary Category    | The main category a product is classified under for browsing and organization.      |
+
+Each card shows:
+
+* A badge displaying either `[N] missing`, in red, if products are missing that field, or `Complete`, in green, if every product has a value.
+* A progress bar reflecting how much of the catalog is covered for that field.
+* The completion percentage and total product (or variant) count it was calculated against, for example, "14% complete · 2798 products".
+
+Click a card to select it, highlighted with a blue border, and load the list of products missing that field below.
+
+### Look Up Another Field
+
+Beyond the default fields shown as cards, the `Look up another field` section lets users check completeness for any other field, by name, for example, `brandName`, `upc`, or `mainImageUrl`. Enter the field name and click `LOOK UP` to load matching results.
+
+### Products Missing a Field
+
+Once a field is selected, either from a card or via lookup, the page lists every product missing that field under the heading `[N] products missing [Field]`. Each row shows the variant name, `SKU`, parent product name, and any associated tags, the same as on the `Product Workbench` list. Click a row to open that product's `Product Details` page and fill in the missing value.
+
+

--- a/documents/store-operations/products/product-details.md
+++ b/documents/store-operations/products/product-details.md
@@ -1,0 +1,202 @@
+# Product Details
+
+When you select a product from the **Product List**, you are redirected to the **Product Details** page.
+
+The **Product Details** page provides a complete view of a product and allows users to manage and update different product attributes. It is the central place to configure product information such as display details, identifiers, pricing, inventory settings, shipping details, and external channel mappings.
+
+Users can view, edit, and manage different sections of a product from this page.
+
+
+## Product Types
+
+Product types define the nature of a product and how it is managed within the system. Different product types help determine inventory handling, fulfillment process, pricing, and product configuration.
+
+
+| Product Type | Description | Example |
+|--------------|-------------|---------|
+| **Configurable Good** | A physical product with multiple variations. | T-shirt with different sizes and colors |
+| **Configurable Good Configuration** | A specific variation of a configurable product. | Red T-shirt - Medium |
+| **Configurable Service (Using Inventory)** | A service that requires inventory or resources. | Installation with required parts |
+| **Configurable Service Configuration** | Different options available for a service. | Basic or Premium installation |
+| **Digital Good** | A product delivered electronically without shipping. | Software license, E-book |
+| **Donation Product** | A product used to collect contributions. | Charity donation |
+| **Finished Good** | A completed product ready for sale. | Laptop, Mobile phone |
+| **Finished/Digital Good** | A product available in physical and digital formats. | Physical book and E-book |
+| **Gift Card** | A prepaid product with monetary value. | Store gift card |
+| **Good** | A general physical product managed through inventory. | Furniture, Electronics |
+| **Marketing Package** | Multiple products sold together as one package. | Laptop bundle with accessories |
+| **Marketing Package: Auto (Pick)** | A package where items are automatically selected from inventory. | Automatically created gift basket |
+| **Marketing Package: Pick Assembly** | A package assembled from individual products before shipping. | Custom computer package |
+| **Raw Material** | Material used to manufacture other products. | Fabric, Steel |
+| **Service** | A non-physical product offered to customers. | Consultation, Maintenance |
+| **Subassembly** | A partially completed product used in manufacturing. | Engine assembly |
+| **Work In Process (WIP)** | A product currently being manufactured. | Partially assembled machine |
+
+---
+
+## Display
+
+The **Display** section contains the basic information used to identify and describe a product.
+
+Users can view and update:
+
+* **Name**: The name of the product displayed to users.
+* **Internal Name**: The internal name used for managing the product within the system.
+* **Brand Name**: The brand associated with the product.
+* **Type**: Defines the product type, such as Finished Good.
+* **Description**: A short description of the product.
+* **Long Description**: A detailed description of the product.
+
+Click **Save** to apply changes made in this section.
+
+---
+
+## Product Identifications
+
+The **Product Identifications** section contains unique identifiers used to identify a product.
+
+It includes:
+
+* **Product ID**: A unique identifier assigned to the product.
+* **SKU**: Stock Keeping Unit used for inventory and order management.
+* **UPCA**: Universal Product Code used for product identification.
+
+These identifiers help maintain accurate product data across different systems.
+
+---
+
+## Dates
+
+The **Dates** section manages important product lifecycle dates.
+
+Users can configure:
+
+* **Introduction Date**: The date when the product becomes available.
+* **Release Date**: The official product release date.
+* **Support Discontinuation Date**: The date after which product support is stopped.
+* **Sales Discontinuation Date**: The date after which the product is no longer available for sale.
+
+### Discontinue When Out of Stock
+
+This option allows users to mark a product as discontinued when inventory reaches zero.
+
+When enabled:
+* The product will not be restocked.
+* Backorders will not be accepted.
+
+---
+
+## Tags
+
+The **Tags** section allows users to add labels to products for better organization and filtering.
+
+Users can:
+* Add new tags.
+* Remove existing tags.
+
+
+---
+
+## Categories
+
+The **Categories** section allows users to assign products to specific categories.
+
+Users can:
+* View existing categories linked to the product.
+* Add additional categories.
+
+Categories help organize products and improve product discoverability.
+
+---
+
+## Prices
+
+The **Prices** section manages different pricing details for a product.
+
+Users can configure:
+
+* **Currency**: The currency used for product pricing.
+* **Default Price**: The standard selling price of the product.
+* **List Price**: The original or displayed price of the product.
+* **Wholesale Price**: The price used for wholesale transactions.
+
+The **Copy From Parent** option allows users to copy pricing information from the parent product.
+
+---
+
+## Shopify Shop Products
+
+The **Shopify Shop Products** section displays the connection between the product and Shopify.
+
+It includes:
+
+* **Shop ID**: Identifies the connected Shopify store.
+* **Shopify Product ID**: Unique identifier of the product in Shopify.
+* **Shopify Inventory ID**: Identifier used for inventory synchronization.
+
+Users can:
+* Add a Shopify product mapping.
+* Edit existing Shopify mappings.
+* Remove Shopify mappings.
+
+---
+
+## Inventory Policy
+
+The **Inventory Policy** section controls how inventory-related rules are applied to the product.
+
+Users can configure:
+
+### Returnable
+
+Defines whether the product can be returned.
+
+* Enabled: Product can be returned.
+* Disabled: Product cannot be returned.
+
+### Taxable
+
+Defines whether tax should be applied to the product.
+
+* Enabled: Product is taxable.
+* Disabled: Product is not taxable.
+
+### Substitutes
+
+Users can link substitute products that can be used when the original product is unavailable.
+
+---
+
+## Shipping and Handling
+
+The **Shipping and Handling** section contains product shipping-related information.
+
+Users can configure:
+
+* **Default Box Type**: Defines the standard packaging type used for shipping.
+* **Width**: Product package width.
+* **Height**: Product package height.
+* **Depth**: Product package depth.
+* **Weight**: Product package weight.
+
+##### Additional options:
+
+* **In Shipping Box**: Indicates whether the product is already packed inside a shipping box.
+
+* **Charge Shipping**: Defines whether shipping charges should be applied for the product.
+
+The product dimensions are used to preview the package size and support accurate shipping calculations.
+
+--- 
+## Change History
+
+The **Change History** section keeps track of updates made to the product.
+
+It helps users review:
+* Previous changes.
+* Product update history.
+* Changes made by users.
+---
+
+
+

--- a/documents/store-operations/products/product-workbench.md
+++ b/documents/store-operations/products/product-workbench.md
@@ -21,7 +21,7 @@ Applied filters are highlighted, and the result count at the top of the list upd
 
 ### Select Products and Add Tags
 
-Each product row has a checkbox, and the `Select all` checkbox above the list selects every product currently in the result set. Once one or more products are selected, click `ADD TAGS`. The `ADD TAGS` button will display list of tags, select desired tags and click `Add`. 
+Each product row has a checkbox, and the `Select all` checkbox above the list selects every product currently in the result set. Once one or more products are selected, click `ADD TAGS` to display a list of tags, select the desired tags, and click `Add`.
 
 ### Sort Results
 

--- a/documents/store-operations/products/product-workbench.md
+++ b/documents/store-operations/products/product-workbench.md
@@ -15,7 +15,7 @@ Below the search bar, the Product Workbench page offers a row of filters to narr
 | Product Type      | Filters products by type, such as `Finished Good` or `Digital Good`.                               |
 | Product Store     | Filters products belonging to a specific store, since each brand's product store maintains its own catalog. |
 | Virtual/Variant   | Filters results to show only parent (`Virtual`) products or only their `Variants`.                 |
-| Tags   | Filters products by tags .                 |
+| Tags   | Filters products by tags.                 |
 
 Applied filters are highlighted, and the result count at the top of the list updates immediately to reflect the active filter combination. Click the red `x` icon next to the filters row to clear all applied filters and search terms at once.
 

--- a/documents/store-operations/products/product-workbench.md
+++ b/documents/store-operations/products/product-workbench.md
@@ -25,7 +25,7 @@ Each product row has a checkbox, and the `Select all` checkbox above the list se
 
 ### Sort Results
 
-The `Sort` dropdown, on the top right of the result list, controls the order in which products are displayed. By default, results are sorted `Alphabetically`. User can also sort the results by `Recently Updated`, or `Recently Created`. 
+The `Sort` dropdown, on the top right of the result list, controls the order in which products are displayed. By default, results are sorted `Alphabetically`. You can also sort the results by `Recently Updated`, or `Recently Created`.
 
 ### Product List
 

--- a/documents/store-operations/products/product-workbench.md
+++ b/documents/store-operations/products/product-workbench.md
@@ -1,0 +1,41 @@
+# Product Workbench
+
+The `Product Workbench` page is the central place to find and manage products. It displays both parent products and their individual variants, along with key identifiers and tags, so users can quickly locate the exact item they're looking for and jump into its details.
+
+### Search Products
+
+The `Search Bar` at the top of the Product Workbench lets users search products by `Product ID`, `SKU`, `UPC`, or product `Name`. As soon as a search term is entered, the result list updates to show every parent product and variant matching the keyword, along with a running result count (for example, "314 results").
+
+### Filter Products
+
+Below the search bar, the Product Workbench page offers a row of filters to narrow down search results further:
+
+| **Filter**       | **Description**                                                                                  |
+| ----------------- | --------------------------------------------------------------------------------------------------- |
+| Product Type      | Filters products by type, such as `Finished Good` or `Digital Good`.                               |
+| Product Store     | Filters products belonging to a specific store, since each brand's product store maintains its own catalog. |
+| Virtual/Variant   | Filters results to show only parent (`Virtual`) products or only their `Variants`.                 |
+| Tags   | Filters products by tags .                 |
+
+Applied filters are highlighted, and the result count at the top of the list updates immediately to reflect the active filter combination. Click the red `x` icon next to the filters row to clear all applied filters and search terms at once.
+
+### Select Products and Add Tags
+
+Each product row has a checkbox, and the `Select all` checkbox above the list selects every product currently in the result set. Once one or more products are selected, click `ADD TAGS`. The `ADD TAGS` button will display list of tags, select desired tags and click `Add`. 
+
+### Sort Results
+
+The `Sort` dropdown, on the top right of the result list, controls the order in which products are displayed. By default, results are sorted `Alphabetically`. User can also sort the results by `Recently Updated`, or `Recently Created`. 
+
+### Product List
+
+Each row in the result list represents either a parent product or a single variant, and displays:
+
+* A thumbnail image, or a placeholder icon when no image is available.
+* The product/variant name (for example, `100 / Black`).
+* The `Product ID` or `SKU`, followed by the parent product name.
+* Any tags or type labels associated with the product, such as `giftcard`, `Pre-order`, or category tags like `Bottom` and `Women`.
+
+Click anywhere on a row to open that product's `Product Details` page.
+
+

--- a/documents/store-operations/products/products-app.md
+++ b/documents/store-operations/products/products-app.md
@@ -1,0 +1,21 @@
+# Products App
+
+The **Products App** is HotWax Commerce's Product Information Management (PIM) system. It helps businesses manage and maintain product information in one place. The app ensures that product data is accurate, complete, and ready to be used across different sales channels.
+
+## Key Features
+
+The app helps catalog administrators and store managers manage important product information:
+
+* **Product Data Management**: Maintain and standardize important product details such as product IDs, SKUs, and barcodes.
+
+* **Data Validation**: Identify missing product information and duplicate barcodes to prevent issues with order routing and fulfillment.
+
+* **Channel Synchronization Tracking**: Track product updates synced from external eCommerce platforms like Shopify.
+
+* **Pricing and Shipping Management**: Manage product pricing details and shipping-related information such as carrier settings.
+
+## Pre-requisites to Use the App
+
+To access the Products App, users must have the `PRODUCTS_APP_VIEW` permission.
+
+

--- a/documents/store-operations/products/products-app.md
+++ b/documents/store-operations/products/products-app.md
@@ -1,6 +1,6 @@
 # Products App
 
-The **Products App** is HotWax Commerce's Product Information Management (PIM) system. It helps businesses manage and maintain product information in one place. The app ensures that product data is accurate, complete, and ready to be used across different sales channels.
+The **Products App** is HotWax Commerce's Product Information Management (PIM) system. It helps businesses manage and maintain product information in one place. The app helps keep product data accurate, complete, and ready to be used across different sales channels.
 
 ## Key Features
 


### PR DESCRIPTION
## Summary
This PR adds new documentation for the **Products App** under `documents/store-operations/products/`. 

## Pages Added
- Product Workbench — search, filter, bulk tagging, and the product list
- Product Details — parent/variant editing, pricing, tags, categories, Shopify associations, inventory policy, and shipping
- Duplicate Identifiers — finding and resolving duplicate SKUs/UPCs
- Missing Values — the catalog coverage dashboard and field lookup
- Imports — the synced product updates log

## Changes

- No existing documentation was modified.
- All new files follow the established documentation formatting standards for the `store-operations` section.

Closes #1760