### PR TITLE
docs: recover Job Manager locks after OMS restart

### DIFF
--- a/documents/retail-operations/workflow/job-management/job-queueing.md
+++ b/documents/retail-operations/workflow/job-management/job-queueing.md
@@ -73,6 +73,19 @@ This tab lists jobs in the **running status** i.e jobs those are currently in ex
 - **Service Name**: Indicates which OMS service is executing the job.
 - **Running Duration**: Indicates how long the job has been running.
 
+#### Recover a job lock after an OMS restart
+
+An OMS restart can interrupt a job and leave its run lock on the Running tab. When this happens, the job card shows the message `This job has crashed due to a restart, release it`.
+
+Release the lock only when the job card shows this restart message. Do not release a job only because it has been running for a long time. Investigate long-running jobs before taking action.
+
+1. Open the `Running` tab in Job Manager.
+2. Find the job card with the restart message.
+3. Select the release control on the job card and confirm the action.
+4. Check the `History` tab and your job monitoring after the next scheduled run.
+
+Releasing the restart-identified lock clears the stale lock so the job can run again according to its configuration. If the job fails again or does not run as expected, investigate the failure before releasing another lock.
+
 
 
 #### 3. History Tab

--- a/documents/retail-operations/workflow/job-management/job-queueing.md
+++ b/documents/retail-operations/workflow/job-management/job-queueing.md
@@ -73,13 +73,13 @@ This tab lists jobs in the **running status** i.e jobs those are currently in ex
 - **Service Name**: Indicates which OMS service is executing the job.
 - **Running Duration**: Indicates how long the job has been running.
 
-#### Recover a job lock after an OMS restart
+#### Recover a job lock after an Order Management System restart
 
-An OMS restart can interrupt a job and leave its run lock on the Running tab. When this happens, the job card shows the message `This job has crashed due to a restart, release it`.
+An Order Management System restart can interrupt a job and leave its run lock on the `Running` tab. When this happens, the job card shows the message `This job has crashed due to a restart, release it`.
 
 Release the lock only when the job card shows this restart message. Do not release a job only because it has been running for a long time. Investigate long-running jobs before taking action.
 
-1. Open the `Running` tab in Job Manager.
+1. Open the `Running` tab in **Job Manager**.
 2. Find the job card with the restart message.
 3. Select the release control on the job card and confirm the action.
 4. Check the `History` tab and your job monitoring after the next scheduled run.

--- a/documents/retail-operations/workflow/job-management/troubleshooting/job-failed.md
+++ b/documents/retail-operations/workflow/job-management/troubleshooting/job-failed.md
@@ -8,6 +8,12 @@ description: >-
 
 A scheduled job might fail in HotWax Commerce due to various reasons, such as incorrect parameter settings, outdated information, or conflicts within the system.
 
+## Job remains locked after an OMS restart
+
+A job that was interrupted by an OMS restart can remain on the `Running` tab with a stale lock. If the job card says `This job has crashed due to a restart, release it`, follow the [restart lock recovery steps](../job-queueing.md#recover-a-job-lock-after-an-oms-restart).
+
+Do not use this recovery process for a job that is only marked as long-running. Investigate the job before releasing that type of lock.
+
 ## Identify Failed Jobs Reason
 
 Users can swiftly identify the reasons for a failed job from the `pipeline` page of the `Job Manager` app. This feature allows user to pinpoint the reasons behind failed jobs, facilitating easy troubleshooting of errors. Here's how you can find out the reason behind the failed jobs:

--- a/documents/retail-operations/workflow/job-management/troubleshooting/job-failed.md
+++ b/documents/retail-operations/workflow/job-management/troubleshooting/job-failed.md
@@ -8,9 +8,9 @@ description: >-
 
 A scheduled job might fail in HotWax Commerce due to various reasons, such as incorrect parameter settings, outdated information, or conflicts within the system.
 
-## Job remains locked after an OMS restart
+## Job remains locked after an Order Management System restart
 
-A job that was interrupted by an OMS restart can remain on the `Running` tab with a stale lock. If the job card says `This job has crashed due to a restart, release it`, follow the [restart lock recovery steps](../job-queueing.md#recover-a-job-lock-after-an-oms-restart).
+A job that was interrupted by an Order Management System restart can remain on the `Running` tab with a stale lock. If the job card says `This job has crashed due to a restart, release it`, follow the [restart lock recovery steps](../job-queueing.md#recover-a-job-lock-after-an-order-management-system-restart).
 
 Do not use this recovery process for a job that is only marked as long-running. Investigate the job before releasing that type of lock.
 


### PR DESCRIPTION
## Business summary

Gives operations users a safe, documented recovery path for Job Manager locks left after an OMS restart, avoiding unnecessary releases of ordinary long-running jobs.

## What changed

- Added restart-specific lock recovery steps to the Job Queueing Running tab.
- Linked Job Failed troubleshooting to the recovery flow.
- Defined when to release a lock and when to investigate first.

## Evidence

- Source behavior: https://github.com/hotwax/oms/pull/764
- Merged OMS commit: 9dcbb24945b7c6d5d77a4a4b03ef98ac1bca91c3

## Verification

- Confirmed the relative troubleshooting link and heading fragment resolve.
- Ran git diff --check.
- Ran markdownlint-cli2; the changed lines pass. The two legacy files retain 16 pre-existing lint findings outside this diff.

Closes #1756