### PR TITLE
docs: explain QOH inventory resets

### DIFF
--- a/documents/learn-netsuite/synchronization-flows/product-inventory-sync/inventory-reset.md
+++ b/documents/learn-netsuite/synchronization-flows/product-inventory-sync/inventory-reset.md
@@ -26,3 +26,11 @@ HC_uploadCSV_InventoryItems
 Import inventory
 FTP Config: RESET_INVENTORY
 ```
+
+## Reset inventory by quantity on hand
+
+Use a quantity-on-hand (QOH) reset when NetSuite is the source of truth for a facility's physical inventory and the reset file contains the physical count. The OMS compares the QOH in the file with its current QOH, then applies the difference to both QOH and available to promise (ATP). This calculation does not preserve existing reservations.
+
+For example, if the OMS has QOH of 10 and ATP of 5, and NetSuite sends QOH of 4, the OMS applies a delta of -6. The resulting QOH is 4 and ATP is -1.
+
+Use this method only when the file represents a physical inventory count. For the field-level configuration and alternative reset methods, see [inventory reset configurations](../../../system-admin/administration/data-manager/freq-used-configurations.md#reset-inventory-by-qoh).


### PR DESCRIPTION
## Summary
Adds the QOH-reset calculation, a concrete example, and a link to the detailed reset configuration reference in the NetSuite inventory-reset flow.

## Business impact
Integration operators can choose the correct reset method and understand how a physical-count reset affects QOH and ATP.

## Evidence
Closes #991. The calculation and example match the existing Reset Inventory by QOH configuration reference.

## Validation
- `git diff --check`
- `codespell --ignore-words=hotwax-dictionary.txt`
- `markdownlint-cli2`