### PR TITLE
Document ADOC Retail Pro invoicing trigger

### DIFF
--- a/adoc/flows/SalesOrders/OrderInvoicing.md
+++ b/adoc/flows/SalesOrders/OrderInvoicing.md
@@ -1,0 +1,27 @@
+---
+description: ADOC's Retail Pro invoicing flow after all order items are packed.
+---
+
+# Order invoicing
+
+For ADOC eCommerce orders, HotWax Commerce sends an order to Retail Pro for invoicing after every order item has been packed. This replaces the previous trigger that waited until the order had been marked as shipped.
+
+## When an order becomes eligible
+
+An order becomes eligible for the Retail Pro invoicing flow when all of its items are in the packed state. The shipment can still be awaiting its handoff or shipment update; that later update is not the invoicing trigger.
+
+{% hint style="info" %}
+This flow applies to ADOC eCommerce orders. POS send-sale orders are not part of this flow because they are invoiced when they are created in Retail Pro.
+{% endhint %}
+
+## Retail Pro processing
+
+HotWax Commerce uses Retail Pro's OrderToInvoice API to create the invoice. For an order fulfilled from more than one store, one store is used as the invoicing store and Retail Pro inventory transfers reconcile stock from the other shipping stores.
+
+## What changed
+
+| Previous flow | Current flow |
+| --- | --- |
+| Send the order for invoicing after it was packed and marked as shipped. | Send the order for invoicing after all order items are packed. |
+
+This change moves the invoicing trigger earlier in the fulfillment lifecycle. It does not change how a shipment is subsequently handed over or marked as shipped.

--- a/adoc/flows/SalesOrders/OrderInvoicing.md
+++ b/adoc/flows/SalesOrders/OrderInvoicing.md
@@ -11,7 +11,7 @@ For ADOC eCommerce orders, HotWax Commerce sends an order to Retail Pro for invo
 An order becomes eligible for the Retail Pro invoicing flow when all of its items are in the packed state. The shipment can still be awaiting its handoff or shipment update; that later update is not the invoicing trigger.
 
 {% hint style="info" %}
-This flow applies to ADOC eCommerce orders. POS send-sale orders are not part of this flow because they are invoiced when they are created in Retail Pro.
+This flow applies to ADOC eCommerce orders. Point of sale send-sale orders are not part of this flow because they are invoiced when they are created in Retail Pro.
 {% endhint %}
 
 ## Retail Pro processing


### PR DESCRIPTION
## Summary
- documents the ADOC-specific Retail Pro invoicing trigger after all order items are packed
- distinguishes the new trigger from the previous packed-and-shipped flow
- retains the documented multi-store Retail Pro invoicing and inventory-transfer context

Evidence: issue #1218, reconciled against the historical ADOC Order Invoicing flow. This PR intentionally does not add unverified operational procedures or generic risk guidance.

Closes #1218

## Validation
- `git diff --check`
- `codespell adoc/flows/SalesOrders/OrderInvoicing.md`