### PR TITLE
Add Re-route Fulfillment user manual

### DIFF
--- a/documents/store-operations/SUMMARY.md
+++ b/documents/store-operations/SUMMARY.md
@@ -12,6 +12,7 @@
   * [Ship to Store](bopis/ship-to-store.md)
   * [Catalog Page](bopis/catalog-page.md)
   * [Settings Page](bopis/settings-page.md)
+  * [Re-route Fulfillment](bopis/re-route-fulfillment.md)
   * [Troubleshooting](bopis/troubleshooting/README.md)
     * [Notification Error](bopis/troubleshooting/notifications-error.md)
 * [Fulfillment App](fulfillment/README.md)

--- a/documents/store-operations/bopis/open-orders-page.md
+++ b/documents/store-operations/bopis/open-orders-page.md
@@ -34,7 +34,7 @@ To reject an order, store associates can click the `bin` icon, choose a reason i
 
 To partially reject an order, the `bin` icon can be used for the specific item that needs to be rejected, followed by selecting a reason and clicking `Reject Item`.
 
-After an item is rejected, a notification email is sent, and the order may be rerouted. For more details, refer to the Re-Routing App User Manual.
+After an item is rejected, a notification email is sent, and the order may be rerouted. For more details, see [Re-route Fulfillment](re-route-fulfillment.md).
 
 ### Customer and Payment Details
 

--- a/documents/store-operations/bopis/order-details-page/README.md
+++ b/documents/store-operations/bopis/order-details-page/README.md
@@ -32,7 +32,7 @@ Click on bin icon to reject the order, select an appropriate reason for rejectin
 
 To reject an order partially, click on the bin icon for the particular item in the order that needs to be rejected, select an appropriate reason for rejecting the item in the pop-up window that appears, and click on the `reject item` button.
 
-If items are rejected, a notification email is also sent, and the order may be re-routed. For more information, refer to the Order Re-Routing App User Manual. 
+If items are rejected, a notification email is also sent, and the order may be re-routed. For more information, see [Re-route Fulfillment](../re-route-fulfillment.md).
 
 ### Customer and Payment Details
 

--- a/documents/store-operations/bopis/re-route-fulfillment.md
+++ b/documents/store-operations/bopis/re-route-fulfillment.md
@@ -4,7 +4,7 @@ description: Help customers choose a new fulfillment option after a BOPIS item i
 
 # Re-route Fulfillment
 
-When a store rejects one or more items from a BOPIS order, the customer can receive a Re-route Fulfillment link. The options shown in that experience are controlled by the product-store **Order Edit Permissions** in the BOPIS app.
+When a store rejects one or more items from a Buy Online Pick-Up In Store (BOPIS) order, the customer can receive a Re-route Fulfillment link. The options shown in that experience are controlled by the product-store `Order Edit Permissions` in the BOPIS app.
 
 ## Before you begin
 
@@ -25,7 +25,7 @@ When pickup-location editing is enabled, the experience suggests a location that
 
 ### Allow item splitting
 
-When **Order Item Split** is enabled, customers can select a different pickup location for each affected item. Updated items are grouped by their selected fulfillment location.
+When `Order Item Split` is enabled, customers can select a different pickup location for each affected item. Updated items are grouped by their selected fulfillment location.
 
 ### Keep items together
 
@@ -33,7 +33,7 @@ When item splitting is not enabled, customers are shown pickup locations that ca
 
 ## Handle items unavailable everywhere
 
-Items that are unavailable at every eligible pickup location appear in an **Out of Stock** group. Customers can request cancellation for those items from the Re-route Fulfillment experience, including when the product store does not normally allow direct item cancellation.
+Items that are unavailable at every eligible pickup location appear in an `Out of Stock` group. Customers can request cancellation for those items from the Re-route Fulfillment experience, including when the product store does not normally allow direct item cancellation.
 
 ## Change another fulfillment detail
 

--- a/documents/store-operations/bopis/re-route-fulfillment.md
+++ b/documents/store-operations/bopis/re-route-fulfillment.md
@@ -1,0 +1,44 @@
+---
+description: Help customers choose a new fulfillment option after a BOPIS item is rejected.
+---
+
+# Re-route Fulfillment
+
+When a store rejects one or more items from a BOPIS order, the customer can receive a Re-route Fulfillment link. The options shown in that experience are controlled by the product-store **Order Edit Permissions** in the BOPIS app.
+
+## Before you begin
+
+In the BOPIS app, go to `Settings` > `Order Edit Permissions` and enable the customer actions that your product store supports. These can include changing the delivery method or address, choosing another pickup location, splitting items, requesting cancellation, and changing the shipment method.
+
+## Re-route a rejected order
+
+1. Reject the unavailable item from the BOPIS order.
+2. The customer receives the rejection notification with the Re-route Fulfillment link.
+3. The customer opens the link and reviews the available options for the rejected items.
+4. The customer selects a new fulfillment option and submits the update.
+
+The available actions depend on the product-store permissions and the inventory available at eligible locations.
+
+## Choose a pickup location
+
+When pickup-location editing is enabled, the experience suggests a location that can fulfill all the affected items. If no single location can fulfill every item, it suggests the nearest location with the most available items, using the original pickup location as the proximity reference.
+
+### Allow item splitting
+
+When **Order Item Split** is enabled, customers can select a different pickup location for each affected item. Updated items are grouped by their selected fulfillment location.
+
+### Keep items together
+
+When item splitting is not enabled, customers are shown pickup locations that can fulfill all affected items together. After a location is selected, the customer can review and edit that selection before submitting it.
+
+## Handle items unavailable everywhere
+
+Items that are unavailable at every eligible pickup location appear in an **Out of Stock** group. Customers can request cancellation for those items from the Re-route Fulfillment experience, including when the product store does not normally allow direct item cancellation.
+
+## Change another fulfillment detail
+
+Depending on the enabled permissions, customers can also update the delivery method, delivery address, or shipment method. They can request cancellation before fulfillment when that permission is enabled.
+
+{% hint style="info" %}
+The Re-route link is secured for the affected order. Do not share it outside the customer-support interaction for that order.
+{% endhint %}


### PR DESCRIPTION
## Summary
- adds a BOPIS Re-route Fulfillment user manual
- documents permissions, split pickup selection, suggested locations, and out-of-stock cancellation requests
- links the manual from existing rejected-order guidance

Grounded in the issue-provided Re-route product document and product update, reconciled with current BOPIS settings and reroute API documentation.

Closes #1278

## Validation
- `git diff --check`
- `codespell` on changed content