### PR TITLE
Update ADOC brokering schedule and dark-store support

### DIFF
--- a/adoc/flows/SalesOrders/BrokeringAndFulfillment.md
+++ b/adoc/flows/SalesOrders/BrokeringAndFulfillment.md
@@ -1,0 +1,30 @@
+---
+description: ADOC brokering schedule and fulfillment-network overview.
+---
+
+# Brokering and fulfillment
+
+ADOC fulfills eCommerce orders through its fulfillment network, which includes retail stores and supported dark stores. HotWax Commerce brokers orders to eligible fulfillment locations and supports country-specific carrier integrations for shipping labels.
+
+## Brokering schedule
+
+Brokering does not run between **11:00 PM and 6:00 AM** for ADOC. Outside that window, the configured brokering schedule processes eligible orders for fulfillment.
+
+{% hint style="info" %}
+The blackout window is specific to ADOC. Do not apply it to another product store unless that store's routing configuration has been approved separately.
+{% endhint %}
+
+## Fulfillment locations
+
+Retail stores and dark stores can participate in ADOC fulfillment. The locations eligible for a particular order are determined by the active ADOC routing configuration and available inventory.
+
+## Carrier integrations
+
+| Country | Carrier |
+| --- | --- |
+| El Salvador | C807 |
+| Guatemala | Guatex |
+| Nicaragua | Cargo Trans |
+| Costa Rica | Terminal Express |
+
+For country-specific routing and carrier setup, follow the approved ADOC implementation configuration.

--- a/adoc/flows/SalesOrders/BrokeringAndFulfillment.md
+++ b/adoc/flows/SalesOrders/BrokeringAndFulfillment.md
@@ -4,11 +4,11 @@ description: ADOC brokering schedule and fulfillment-network overview.
 
 # Brokering and fulfillment
 
-ADOC fulfills eCommerce orders through its fulfillment network, which includes retail stores and supported dark stores. HotWax Commerce brokers orders to eligible fulfillment locations and supports country-specific carrier integrations for shipping labels.
+ADOC fulfills ecommerce orders through its fulfillment network, which includes retail stores and supported dark stores. HotWax Commerce brokers orders to eligible fulfillment locations and supports country-specific carrier integrations for shipping labels.
 
 ## Brokering schedule
 
-Brokering does not run between **11:00 PM and 6:00 AM** for ADOC. Outside that window, the configured brokering schedule processes eligible orders for fulfillment.
+Brokering does not run between 11:00 PM and 6:00 AM for ADOC. Outside that window, the configured brokering schedule processes eligible orders for fulfillment.
 
 {% hint style="info" %}
 The blackout window is specific to ADOC. Do not apply it to another product store unless that store's routing configuration has been approved separately.


### PR DESCRIPTION
## Summary
- documents the ADOC 11 PM to 6 AM brokering blackout window
- updates the fulfillment-network overview to include supported dark stores
- preserves only the verified carrier mapping and configuration boundary

Evidence: issue #1475, reconciled with the historical ADOC Brokering and Fulfillment flow. This PR intentionally avoids unverified dark-store routing rules.

Closes #1475

## Validation
- `git diff --check`
- `codespell adoc/flows/SalesOrders/BrokeringAndFulfillment.md`