### PR TITLE
Improve BOPIS guide clarity and consistency

### DIFF
--- a/documents/store-operations/bopis/catalog-page.md
+++ b/documents/store-operations/bopis/catalog-page.md
@@ -9,7 +9,7 @@ description: >-
 
 ## Catalog Page
 
-The Catalog can be accessed by selecting the `Catalog` button in the BOPIS app's bottom tab. It displays products available for store pickup on the e-commerce platform and can be used to search for products, view product details, and check inventory availability.
+The Catalog can be accessed by selecting the `Catalog` button in the BOPIS App's bottom tab. It displays products available for store pickup on the e-commerce platform and can be used to search for products, view product details, and check inventory availability.
 
 #### Search Product
 

--- a/documents/store-operations/bopis/catalog-page.md
+++ b/documents/store-operations/bopis/catalog-page.md
@@ -9,7 +9,7 @@ description: >-
 
 ## Catalog Page
 
-The Catalog can be accessed by clicking on the `Catalog` button on the bottom tab of the BOPIS app. It displays a list of all the products available for store pickup on the e-commerce platform, and it can be used to search for products, view product details, and their check inventory availability.
+The Catalog can be accessed by selecting the `Catalog` button in the BOPIS app's bottom tab. It displays products available for store pickup on the e-commerce platform and can be used to search for products, view product details, and check inventory availability.
 
 #### Search Product
 

--- a/documents/store-operations/bopis/open-orders-page.md
+++ b/documents/store-operations/bopis/open-orders-page.md
@@ -5,7 +5,7 @@ description: >-
 # Open Orders Page
 
 ## Order Details Card
-The order card shows details that store staff need at a glance. To check the number of units currently in stock, store associates need to click the small `box` icon next to the product details. To view the inventory computation, including quantity on hand, safety stock, reserved quantities, and online ATP, they can click the `info` icon.  
+The order card shows details that store staff need at a glance. To check the number of units currently in stock, store associates select the `box` icon next to the product details. Select the `info` icon to view inventory details such as quantity on hand, safety stock, reserved quantities, and online ATP.
 The order card displays the order name, product image, SKU, and the time since the order was created.
 
 At the bottom of the card, three action buttons are available:

--- a/documents/store-operations/bopis/open-orders-page.md
+++ b/documents/store-operations/bopis/open-orders-page.md
@@ -5,7 +5,7 @@ description: >-
 # Open Orders Page
 
 ## Order Details Card
-The order card shows details that store staff need at a glance. To check the number of units currently in stock, store associates select the `box` icon next to the product details. Select the `info` icon to view inventory details such as quantity on hand, safety stock, reserved quantities, and online ATP.
+The order card shows details that store staff need at a glance. To check the number of units currently in stock, select the `box` icon next to the product details. Select the `info` icon to view inventory details such as quantity on hand, safety stock, reserved quantities, and online ATP.
 The order card displays the order name, product image, SKU, and the time since the order was created.
 
 At the bottom of the card, three action buttons are available:

--- a/documents/store-operations/bopis/order-details-page/README.md
+++ b/documents/store-operations/bopis/order-details-page/README.md
@@ -23,7 +23,7 @@ Below this section, the [cancellation sync job](/documents/retail-operations/wor
 
 - If both the cancellation sync job and the Shopify setting to process refunds are enabled, the cancellation and refund will be sent to Shopify.
 - If the cancellation sync job is enabled but the Shopify refund setting is disabled, only the cancellation will be sent to Shopify.
-- If the cancellation sync job is disabled, neither the cancellation nor the refund is sent to Shopify, even if the Shopify refund setting is enabled.
+- If the `cancellation sync` job is disabled, neither the cancellation nor the refund is sent to Shopify, even if the Shopify refund setting is enabled.
 - If both settings are disabled, no data is sent to Shopify.
 
 ### Reject Orders

--- a/documents/store-operations/bopis/order-details-page/README.md
+++ b/documents/store-operations/bopis/order-details-page/README.md
@@ -23,7 +23,7 @@ Below this section, the [cancellation sync job](/documents/retail-operations/wor
 
 - If both the cancellation sync job and the Shopify setting to process refunds are enabled, the cancellation and refund will be sent to Shopify.
 - If the cancellation sync job is enabled but the Shopify refund setting is disabled, only the cancellation will be sent to Shopify.
-- If the cancellation sync job is disabled, nothing is sent to Shopify, not the cancellation and not the refund, even if the Shopify refund setting is enabled.
+- If the cancellation sync job is disabled, neither the cancellation nor the refund is sent to Shopify, even if the Shopify refund setting is enabled.
 - If both settings are disabled, no data is sent to Shopify.
 
 ### Reject Orders

--- a/documents/store-operations/bopis/packed-order-tab.md
+++ b/documents/store-operations/bopis/packed-order-tab.md
@@ -26,5 +26,5 @@ Below this section, the [cancellation sync job](../../retail-operations/workflow
 
 - If both the `cancellation sync` job and the Shopify setting to process refunds are enabled, the cancellation and refund will be sent to Shopify.
 - If the `cancellation sync` job is enabled but the Shopify refund setting is disabled, only the cancellation will be sent to Shopify.
-- If the `cancellation sync` job is disabled, nothing is sent to Shopify, not the cancellation and not the refund, even if the Shopify refund setting is enabled.
+- If the `cancellation sync` job is disabled, neither the cancellation nor the refund is sent to Shopify, even if the Shopify refund setting is enabled.
 - If both settings are disabled, no data is sent to Shopify.

--- a/documents/store-operations/bopis/ship-to-store.md
+++ b/documents/store-operations/bopis/ship-to-store.md
@@ -71,7 +71,7 @@ The `Ship to Store` page in the BOPIS App is organized into three tabs to help y
 ### Incoming
 This tab displays inventory that has been shipped from the fulfillment center and is currently in transit to your store.
 
-When the physical shipment arrives, locate the order in this tab and label it as `Arrived`. A notification is automatically sent to the customer informing them that their order is now available for pickup, and the order moves to the `Ready for Pickup` tab.
+When the physical shipment arrives, locate the order in this tab and label it as `Arrived`. HotWax Commerce automatically sends a notification to the customer informing them that their order is now available for pickup, and the order moves to the `Ready for Pickup` tab.
 
 ### Ready for pickup
 This tab displays orders that have physically arrived at your store and are waiting for the customer.

--- a/documents/store-operations/bopis/ship-to-store.md
+++ b/documents/store-operations/bopis/ship-to-store.md
@@ -71,7 +71,7 @@ The `Ship to Store` page in the BOPIS App is organized into three tabs to help y
 ### Incoming
 This tab displays inventory that has been shipped from the fulfillment center and is currently in transit to your store.
 
-When the physical shipment arrives, locate the order in this tab and label it `Arrived`. A notification is automatically sent to the customer informing them that their order is now available for pickup, and the order moves to the `Ready for Pickup` tab.
+When the physical shipment arrives, locate the order in this tab and label it as `Arrived`. A notification is automatically sent to the customer informing them that their order is now available for pickup, and the order moves to the `Ready for Pickup` tab.
 
 ### Ready for pickup
 This tab displays orders that have physically arrived at your store and are waiting for the customer.

--- a/documents/store-operations/bopis/troubleshooting/notifications-error.md
+++ b/documents/store-operations/bopis/troubleshooting/notifications-error.md
@@ -22,7 +22,7 @@ Confirm that the BOPIS app has the necessary settings to send notifications. Go 
 
 Verify that OMS instance meets compatibility requirements:
 
-* For BOPIS notifications to work, the instance should be on v.5.2.0. or above
+* For BOPIS notifications to work, the instance should be on v5.2.0 or above.
 
 ### Review Browser Notification Settings
 


### PR DESCRIPTION
## Summary
- clarifies inventory, arrival, catalog, and notification guidance
- corrects cancellation/refund wording in both affected BOPIS pages
- standardizes the required BOPIS version format

Closes #1685

## Validation
- `git diff --check`
- `codespell` on changed BOPIS guides