### PR TITLE
docs: link cycle count to inventory management

### DIFF
--- a/documents/retail-operations/inventory/cycle-count/README.md
+++ b/documents/retail-operations/inventory/cycle-count/README.md
@@ -11,6 +11,8 @@ The app provides distinct views for Admins and Store Associates:
 
 With built-in features like bulk actions, variance alerts, and timestamped tracking, the Cycle Count App keeps inventory accurate across your network.
 
+For a business-process overview of inventory management and cycle counting, see [Inventory management](../../../learn-hotwax-oms/business-processes/inventory-management.md).
+
 ## Cycle count workflow
 
 1. [Plan your count with a preview](../../../store-operations/cycle-count/plan-cycle-count.md)


### PR DESCRIPTION
## Business summary
Gives Cycle Count users a direct path to the broader Inventory Management business-process guide.

## What changed
- Added a relative `Inventory management` link to the Cycle Count landing page.

## Verification
- `git diff --check`
- Confirmed the relative target exists
- `codespell --ignore-words=hotwax-dictionary.txt documents/retail-operations/inventory/cycle-count/README.md`

Closes #1634