### PR TITLE
Docs: prevent BOPIS page-description truncation

### DIFF
--- a/documents/integrate-with-hotwax/oms-release-versions/v7.0.0.md
+++ b/documents/integrate-with-hotwax/oms-release-versions/v7.0.0.md
@@ -1,8 +1,10 @@
 ---
-description: This document outlines v7.0.x release in OMS, beginning with the major release v7.0.0 and followed by a series of hotfixes. Each version includes relevant metadata, image details, diffs, and changelogs.
+description: Release notes and deployment details for OMS v7.0.x.
 ---
 
 # OMS v7.0.O Release
+
+This document outlines the v7.0.x OMS release, beginning with the major v7.0.0 release and followed by a series of hotfixes. Each version includes relevant metadata, image details, diffs, and changelogs.
 
 {% hint style="warning" %}
 Before pushing the OMS v7.0.0 release to production, we need to make sure the maarg is deployed on v4.0.0
@@ -1198,5 +1200,4 @@ Before pushing the OMS v7.4.0 release to production, we need to make sure the ma
 | Diff            | [Link to diff](https://github.com/hotwax/hotwax-oms/compare/v7.5.3...v7.5.4) 
 | Changelog       | [Link to changelog](https://github.com/hotwax/hotwax-oms/releases/tag/v7.5.4) 
 | UpgradeData     | [Link to upgradeData](https://github.com/hotwax/hotwax-oms/blob/v7.5.4/upgrade/v7.5.4/UpgradeData.xml) 
-
 

--- a/documents/store-operations/bopis/README.md
+++ b/documents/store-operations/bopis/README.md
@@ -1,9 +1,11 @@
 ---
 description: >-
- The BOPIS Fulfillment App is designed for store managers and associates, providing a focused interface to Pick, Pack, and Handover store pickup orders. The app also includes features to manage Ship-to-Store items, activate gift cards, and view notifications for new and open orders.
+ Pick, pack, and hand over store pickup orders in the BOPIS Fulfillment App.
 ---
 
 # BOPIS Fulfillment App
+
+The BOPIS Fulfillment App is designed for store managers and associates, providing a focused interface to pick, pack, and hand over store pickup orders. The app also includes features to manage Ship-to-Store items, activate gift cards, and view notifications for new and open orders.
 
 ## Key Features
 

--- a/documents/store-operations/bopis/open-orders-page.md
+++ b/documents/store-operations/bopis/open-orders-page.md
@@ -4,7 +4,7 @@ description: >-
 ---
 # Open Orders Page
 
-The Open Orders page allows store associates to view and manage newly assigned orders that are pending fulfillment. On this page, store associates can filter orders, review order details, pick individual orders or pick orders in batches, print picklists, and begin the fulfillment process.
+The `Open Orders` page allows store associates to view and manage newly assigned orders that are pending fulfillment. On this page, store associates can filter orders, review order details, pick individual orders or pick orders in batches, print picklists, and begin the fulfillment process.
 
 ## Order Details Card
 The order card shows details that store staff need at a glance. To check the number of units currently in stock, store associates need to click the small `box` icon next to the product details. To view the inventory computation, including quantity on hand, safety stock, reserved quantities, and online ATP, they can click the `info` icon.  

--- a/documents/store-operations/bopis/open-orders-page.md
+++ b/documents/store-operations/bopis/open-orders-page.md
@@ -1,8 +1,10 @@
 ---
 description: >-
-  The Open Orders page allows store associates to view and manage newly assigned orders that are pending fulfillment. On this page, store associates can filter orders, review order details, pick individual orders or pick orders in batches, print picklists, and begin the fulfillment process.
+  View and manage newly assigned orders that are pending fulfillment.
 ---
 # Open Orders Page
+
+The Open Orders page allows store associates to view and manage newly assigned orders that are pending fulfillment. On this page, store associates can filter orders, review order details, pick individual orders or pick orders in batches, print picklists, and begin the fulfillment process.
 
 ## Order Details Card
 The order card shows details that store staff need at a glance. To check the number of units currently in stock, store associates need to click the small `box` icon next to the product details. To view the inventory computation, including quantity on hand, safety stock, reserved quantities, and online ATP, they can click the `info` icon.  

--- a/documents/store-operations/bopis/packed-order-tab.md
+++ b/documents/store-operations/bopis/packed-order-tab.md
@@ -5,7 +5,7 @@ description: >-
 
 # Packed Orders Page
 
-The Packed Orders tab displays all orders that have been packed and are ready to be handed over to the customer. From this tab, store associates can view order details, print the packing slip, and send pickup reminder emails.
+The `Packed Orders` tab displays all orders that have been packed and are ready to be handed over to the customer. From this tab, store associates can view order details, print the packing slip, and send pickup reminder emails.
 
 ## Order Details Card
 The order card in the `Packed` Orders page shows the same basic details as in the `Open` Orders page, like order ID, product info, and customer name. However, a few things are different here. Instead of a picklist, store staff can generate a packing slip using the `print` icon.

--- a/documents/store-operations/bopis/packed-order-tab.md
+++ b/documents/store-operations/bopis/packed-order-tab.md
@@ -1,9 +1,11 @@
 ---
 description: >-
-  The Packed Orders tab displays all orders that have been packed and are ready to be handed over to the customer. From this tab, store associates can view order details, print the packing slip, and send pickup reminder emails.
+  View packed orders that are ready for customer handover.
 ---
 
 # Packed Orders Page
+
+The Packed Orders tab displays all orders that have been packed and are ready to be handed over to the customer. From this tab, store associates can view order details, print the packing slip, and send pickup reminder emails.
 
 ## Order Details Card
 The order card in the `Packed` Orders page shows the same basic details as in the `Open` Orders page, like order ID, product info, and customer name. However, a few things are different here. Instead of a picklist, store staff can generate a packing slip using the `print` icon.

--- a/documents/store-operations/fulfillment/README.md
+++ b/documents/store-operations/fulfillment/README.md
@@ -1,9 +1,11 @@
 ---
 description: >-
- The Fulfillment App is designed for store managers and associates, providing a focused interface to easily Pick, Pack, and Ship orders. The app also includes features to create and update rejection reasons, manage carriers and shipping methods, and more.
+ Pick, pack, and ship orders in the Fulfillment App.
 ---
 
 # Fulfillment App
+
+The Fulfillment App is designed for store managers and associates, providing a focused interface to pick, pack, and ship orders. The app also includes features to create and update rejection reasons, manage carriers and shipping methods, and more.
 
 ## Key Features
 

--- a/documents/store-operations/fulfillment/completed-orders.md
+++ b/documents/store-operations/fulfillment/completed-orders.md
@@ -1,9 +1,11 @@
 ---
 description: >-
- The Completed Orders page shows all orders that have been picked, packed, and are ready to ship. On this page, store associates can ship orders in bulk, unpack them if needed, download the manifest, and regenerate shipping labels if required.
+ Manage completed orders that are ready to ship.
 ---
 
 # Completed Orders Page
+
+The `Completed Orders` page shows all orders that have been picked, packed, and are ready to ship. On this page, store associates can ship orders in bulk, unpack them if needed, download the manifest, and regenerate shipping labels if required.
 
 ## Filtering
 

--- a/documents/store-operations/fulfillment/in-progress.md
+++ b/documents/store-operations/fulfillment/in-progress.md
@@ -1,9 +1,11 @@
 ---
 description: >-
- The "In Progress" tab contains orders that have been picked and moved from the "Open" tab. This page is dedicated to the packing stage of fulfillment. Here, associates can activate gift cards, generate documents such as shipping labels and packing slips, and complete the remaining fulfillment steps.
+ Pack orders that have moved from the `Open` tab.
 ---
 
 # In Progress Orders Page
+
+The `In Progress` tab contains orders that have been picked and moved from the `Open` tab. This page is dedicated to the packing stage of fulfillment. Here, associates can activate gift cards, generate documents such as shipping labels and packing slips, and complete the remaining fulfillment steps.
 
 ## Filter Orders by Picklist
 

--- a/documents/store-operations/fulfillment/open-orders.md
+++ b/documents/store-operations/fulfillment/open-orders.md
@@ -1,8 +1,10 @@
 ---
-description: The Open Orders page allows store associates to view and manage newly assigned orders that are pending fulfillment. On this page, store associates can filter orders, review order details, pick individual orders or pick orders in batches, print picklists, and begin the fulfillment process.
+description: View and manage newly assigned orders that are pending fulfillment.
 ---
 
 # Open Orders Page
+
+The `Open Orders` page allows store associates to view and manage newly assigned orders that are pending fulfillment. On this page, store associates can filter orders, review order details, pick individual orders or pick orders in batches, print picklists, and begin the fulfillment process.
 
 ## Notifications
 
@@ -90,4 +92,3 @@ From this page, store associates can:
 
 Once they tap `Pick Order`, the status changes and the order moves to the `In Progress` tab.  
 After packing, the order moves to the `Completed` tab.
-


### PR DESCRIPTION
## Summary
Caps every GitBook page description in the repository at the documented 200-character limit while retaining the complete original context in each affected page body.

## Business impact
Store associates and OMS users get concise page previews without losing operational guidance in the documentation itself.

## Scope
- Shortened the two original BOPIS page descriptions.
- Corrected the six additional over-limit descriptions found by the full-repository audit.
- Preserved each affected page's detailed introductory content in the page body.

## Validation
- Full Markdown front-matter scan: 346 descriptions checked; 0 exceed 200 characters.
- `git diff --check`
- `codespell --ignore-words=hotwax-dictionary.txt` on all affected pages

Closes #1664