### PR TITLE
Docs: add integration infrastructure concepts

### DIFF
--- a/documents/integrate-with-hotwax/SUMMARY.md
+++ b/documents/integrate-with-hotwax/SUMMARY.md
@@ -2,6 +2,8 @@
 
 * [Introduction](README.md)
 
+* [Integration concepts](integration-concepts.md)
+
 ## Components
 
 * [Available to Promise](components/available-to-promise/README.md)

--- a/documents/integrate-with-hotwax/integration-concepts.md
+++ b/documents/integrate-with-hotwax/integration-concepts.md
@@ -1,0 +1,19 @@
+---
+description: Learn how infrastructure services support HotWax Commerce integrations.
+---
+
+# Integration concepts
+
+Use this page for technical infrastructure terms that help explain an integration flow. Keep business and operational terms in the [OMS glossary](../learn-hotwax-oms/README.md).
+
+## Amazon EventBridge
+
+Amazon EventBridge is an AWS service that routes events between systems. In the Shopify order-update flow, it receives the `orders/updated` webhook event and routes the message to an Amazon Simple Queue Service (SQS) queue. See [order updates](../learn-shopify/shopify-integration/orders/order-updates.md) for the workflow.
+
+## Amazon Simple Queue Service
+
+Amazon Simple Queue Service (SQS) is an AWS message queue. In the Shopify order-update flow, it retains routed webhook messages until HotWax Commerce polls the queue for updates. See [order download](../learn-shopify/shopify-integration/orders/order-download.md) for the related routing and polling steps.
+
+## Add technical terms consistently
+
+Add a term here when it describes shared integration infrastructure, such as a messaging, event-routing, or transport service. Link the term to the workflow that uses it. Keep customer-specific endpoints, credentials, and configuration values in the applicable client documentation rather than on this shared page.

--- a/documents/integrate-with-hotwax/integration-concepts.md
+++ b/documents/integrate-with-hotwax/integration-concepts.md
@@ -4,7 +4,7 @@ description: Learn how infrastructure services support HotWax Commerce integrati
 
 # Integration concepts
 
-Use this page for technical infrastructure terms that help explain an integration flow. Keep business and operational terms in the [OMS glossary](../learn-hotwax-oms/README.md).
+Use this page for technical infrastructure terms that help explain an integration flow. Keep business and operational terms in the [order management system (OMS) glossary](../learn-hotwax-oms/README.md).
 
 ## Amazon EventBridge
 
@@ -12,7 +12,7 @@ Amazon EventBridge is an AWS service that routes events between systems. In the 
 
 ## Amazon Simple Queue Service
 
-Amazon Simple Queue Service (SQS) is an AWS message queue. In the Shopify order-update flow, it retains routed webhook messages until HotWax Commerce polls the queue for updates. See [order download](../learn-shopify/shopify-integration/orders/order-download.md) for the related routing and polling steps.
+Amazon SQS is an AWS message queue. In the Shopify order-update flow, it retains routed webhook messages until HotWax Commerce polls the queue for updates. See [order download](../learn-shopify/shopify-integration/orders/order-download.md) for the related routing and polling steps.
 
 ## Add technical terms consistently
 


### PR DESCRIPTION
## Summary
Adds a dedicated home for shared integration-infrastructure terms and links it from the Integrate with HotWax navigation.

## Business impact
Readers can understand technical event-routing terms without expanding the business-facing OMS glossary or mixing client-specific configuration into shared documentation.

## Validation
- `git diff --check`
- `codespell --ignore-words=hotwax-dictionary.txt documents/integrate-with-hotwax/integration-concepts.md documents/integrate-with-hotwax/SUMMARY.md`
- Confirmed all internal navigation and workflow-link targets exist

Closes #1699