### PR TITLE
Docs: standardize inventory availability terms

### DIFF
--- a/documents/learn-hotwax-oms/README.md
+++ b/documents/learn-hotwax-oms/README.md
@@ -4,7 +4,7 @@ description: Learn about common terms in omnichannel order and inventory managem
 
 # Glossary
 
-Use the definitions in this glossary as the canonical reference for Quantity on Hand (QOH), Available to Promise (ATP), and Online ATP. Workflow pages can describe how these values are used in a specific process.
+Use the definitions in this glossary as the canonical reference for quantity on hand (QOH), available to promise (ATP), and online ATP. Workflow pages can describe how these values are used in a specific process.
 
 ### Advanced shipping notice (ASN)
 
@@ -24,7 +24,7 @@ The arrival date is the date when the inventory of the purchase order items is e
 
 ### Available to promise (ATP)
 
-ATP (Available to Promise) is the inventory that can be promised at a facility after inventory reserved for orders is deducted from Quantity on Hand (QOH).\
+ATP (available to promise) is the inventory that can be promised at a facility after inventory reserved for orders is deducted from quantity on hand (QOH).\
 ATP = QOH - Reserved quantities
 
 ### Backorders
@@ -185,7 +185,7 @@ A purchase order (PO) is a document created by a retailer and sent to their supp
 
 ### Quantity on hand (QOH)
 
-QOH is the total physical quantity of a product recorded at a store or warehouse before order reservations and online-selling rules are applied. HotWax Commerce can update QOH from ERP, warehouse management system (WMS), and point of sale (POS) inventory feeds.
+QOH is the total physical quantity of a product recorded at a store or warehouse before order reservations and online-selling rules are applied. HotWax Commerce can update QOH from ERP, WMS, and POS inventory feeds.
 
 ### Rejected orders
 

--- a/documents/learn-hotwax-oms/README.md
+++ b/documents/learn-hotwax-oms/README.md
@@ -4,6 +4,8 @@ description: Learn about common terms in omnichannel order and inventory managem
 
 # Glossary
 
+Use the definitions in this glossary as the canonical reference for Quantity on Hand (QOH), Available to Promise (ATP), and Online ATP. Workflow pages can describe how these values are used in a specific process.
+
 ### Advanced shipping notice (ASN)
 
 An advanced shipping notice (ASN) is a notification sent by a supplier to a recipient detailing the contents and expected arrival of a shipment, often sent in advance of the physical delivery. For example, if a store anticipates receiving 100 shirts in an incoming shipment, the ASN will detail this expected inventory count.
@@ -22,7 +24,7 @@ The arrival date is the date when the inventory of the purchase order items is e
 
 ### Available to promise (ATP)
 
-ATP (Available to Promise) represents the physical quantity of a product at stores or warehouses after deducting the reserved inventory, that is, inventory that has been allocated to online orders from the Quantity on Hand (QOH).\
+ATP (Available to Promise) is the inventory that can be promised at a facility after inventory reserved for orders is deducted from Quantity on Hand (QOH).\
 ATP = QOH - Reserved quantities
 
 ### Backorders
@@ -127,11 +129,10 @@ The maximum order limit is a predefined limit set by a store, indicating the max
 
 ### Online ATP
 
-Online ATP represents the unified inventory pool of actual sellable inventory count that is published on e-commerce platforms and can be promised to customers.
+Online ATP is the sellable inventory total that HotWax Commerce publishes to e-commerce platforms. It starts with QOH and excludes inventory that is unavailable for online sale.
 
-To calculate online ATP, HotWax Commerce deducts inventory that is not available for sale from the ATP. This includes items such as safety stock, threshold quantities, orders in the brokering queue, and inventory from locations that are not participating in online selling.
+The calculation excludes reserved quantities, safety stock, threshold quantities, orders in the brokering queue, and ATP from facilities that do not participate in online selling.
 
-HotWax Commerce calculates online available to promise (ATP):
 Online ATP = QOH - (reserved quantities + safety stock + threshold + orders in brokering queue + excluded facilities’ ATP)
 
 Learn more about [online ATP](./business-process-models/inventory-lifecycle.md#push-online-atp-to-ecommerce).
@@ -184,7 +185,7 @@ A purchase order (PO) is a document created by a retailer and sent to their supp
 
 ### Quantity on hand (QOH)
 
-QOH represents the total physical quantity of a product available at stores or warehouses. HotWax Commerce receives daily inventory feeds from the ERP system to update and maintain inventory data. Additionally, in the absence of ERP systems, HotWax Commerce also receives inventory feeds from Warehouse Management Systems (WMS) and Point of Sale (POS) systems.
+QOH is the total physical quantity of a product recorded at a store or warehouse before order reservations and online-selling rules are applied. HotWax Commerce can update QOH from ERP, warehouse management system (WMS), and point of sale (POS) inventory feeds.
 
 ### Rejected orders
 

--- a/documents/learn-hotwax-oms/how-to-guides/configure-bopis.md
+++ b/documents/learn-hotwax-oms/how-to-guides/configure-bopis.md
@@ -54,7 +54,7 @@ For a product to be available for pickup at Shopify PDP, it must have inventory 
 
 ### ATP Computation
 
-When the inventory is received, a product’s QOH and ATP is updated in HotWax Commerce. HotWax Commerce calculates  [Available to Promise](/documents/retail-operations/inventory/available-to-promise) (ATP) of a facility by considering various factors, such as safety stock, threshold, reserved quantity, and orders in the queue.
+When inventory is received, HotWax Commerce updates QOH and ATP. For the canonical definitions of [QOH and ATP](../README.md#available-to-promise-atp), use the glossary. For a facility, ATP accounts for reserved quantities, safety stock, threshold, and orders in the brokering queue.
 
 ATP = QOH - (Reserved quantities + Safety stock + Threshold + Orders in brokering queue)
 

--- a/documents/learn-hotwax-oms/how-to-guides/configure-store-fulfillment.md
+++ b/documents/learn-hotwax-oms/how-to-guides/configure-store-fulfillment.md
@@ -64,7 +64,7 @@ For a product to be available for store fulfillment, it must have inventory at t
 
 ### Inventory Sync to Shopify
 
-When inventory is received, HotWax Commerce updates QOH and Online ATP. For the canonical definitions of [QOH and Online ATP](../README.md#online-atp), use the glossary. Online ATP is the sellable inventory total after HotWax Commerce applies reservations, safety stock, threshold, brokering queue, and facility-participation rules.
+When inventory is received, HotWax Commerce updates QOH and online ATP. For the canonical definitions of [QOH and online ATP](../README.md#online-atp), use the glossary. Online ATP is the sellable inventory total after HotWax Commerce applies reservations, safety stock, threshold, brokering queue, and facility-participation rules.
 
 Online ATP = QOH - (Reserved quantities + Safety stock + Threshold + Orders in brokering queue + Excluded facilities' ATP)
 

--- a/documents/learn-hotwax-oms/how-to-guides/configure-store-fulfillment.md
+++ b/documents/learn-hotwax-oms/how-to-guides/configure-store-fulfillment.md
@@ -64,7 +64,7 @@ For a product to be available for store fulfillment, it must have inventory at t
 
 ### Inventory Sync to Shopify
 
-When the inventory is received, a product’s QOH and Online ATP are updated in HotWax Commerce. HotWax Commerce calculates the Physical Available to Promise (ATP) of a facility by considering various factors, such as safety stock, threshold, reserved quantity, and orders in the queue.
+When inventory is received, HotWax Commerce updates QOH and Online ATP. For the canonical definitions of [QOH and Online ATP](../README.md#online-atp), use the glossary. Online ATP is the sellable inventory total after HotWax Commerce applies reservations, safety stock, threshold, brokering queue, and facility-participation rules.
 
 Online ATP = QOH - (Reserved quantities + Safety stock + Threshold + Orders in brokering queue + Excluded facilities' ATP)
 


### PR DESCRIPTION
## Summary
Establishes the OMS glossary as the canonical source for QOH, ATP, and Online ATP, and aligns BOPIS and store-fulfillment configuration guidance with those definitions.

## Business impact
Readers can distinguish physical inventory, facility availability, and online sellable inventory without conflicting explanations across setup guides.

## Evidence
- Inventory item totals are maintained separately for QOH and ATP in OMS inventory services.
- The online ATP service applies threshold and queue exclusions before returning sellable availability.

## Validation
- `git diff --check`
- `codespell --ignore-words=hotwax-dictionary.txt documents/learn-hotwax-oms/README.md documents/learn-hotwax-oms/how-to-guides/configure-bopis.md documents/learn-hotwax-oms/how-to-guides/configure-store-fulfillment.md`

Closes #1701