### PR TITLE
Document order estimated ship & delivery dates

### DIFF
--- a/documents/learn-hotwax-oms/SUMMARY.md
+++ b/documents/learn-hotwax-oms/SUMMARY.md
@@ -30,4 +30,5 @@
 
 * [How to Configure BOPIS](how-to-guides/configure-bopis.md)
 * [Configure Estimated Delivery Dates](how-to-guides/configure-estimated-delivery-dates.md)
+* [Order Estimated Ship & Delivery Dates](how-to-guides/order-estimated-ship-delivery-dates.md)
 * [How to Configure Store Fulfillment](how-to-guides/configure-store-fulfillment.md)

--- a/documents/learn-hotwax-oms/SUMMARY.md
+++ b/documents/learn-hotwax-oms/SUMMARY.md
@@ -30,5 +30,5 @@
 
 * [How to Configure BOPIS](how-to-guides/configure-bopis.md)
 * [Configure Estimated Delivery Dates](how-to-guides/configure-estimated-delivery-dates.md)
-* [Order Estimated Ship & Delivery Dates](how-to-guides/order-estimated-ship-delivery-dates.md)
+* [Order estimated ship and delivery dates](how-to-guides/order-estimated-ship-delivery-dates.md)
 * [How to Configure Store Fulfillment](how-to-guides/configure-store-fulfillment.md)

--- a/documents/learn-hotwax-oms/how-to-guides/configure-estimated-delivery-dates.md
+++ b/documents/learn-hotwax-oms/how-to-guides/configure-estimated-delivery-dates.md
@@ -9,7 +9,7 @@ An estimated delivery date tells a shopper when an item can arrive before they p
 The exact rules vary by retailer. For example, one retailer may promise standard delivery by adding transit days based on the distance from the fulfillment location, while another may use a carrier service level. Define these rules with the team responsible for the storefront before enabling the experience.
 
 {% hint style="info" %}
-This page covers the pre-purchase estimate shown on the storefront. Once an order is placed, HotWax Commerce records an estimated ship date and estimated delivery date on the order itself — see [Order Estimated Ship & Delivery Dates](order-estimated-ship-delivery-dates.md).
+This page covers the pre-purchase estimate shown on the storefront. Once an order is placed, HotWax Commerce records an estimated ship date and estimated delivery date on the order itself. See [Order estimated ship and delivery dates](order-estimated-ship-delivery-dates.md).
 {% endhint %}
 
 ## How the date is calculated

--- a/documents/learn-hotwax-oms/how-to-guides/configure-estimated-delivery-dates.md
+++ b/documents/learn-hotwax-oms/how-to-guides/configure-estimated-delivery-dates.md
@@ -8,6 +8,10 @@ An estimated delivery date tells a shopper when an item can arrive before they p
 
 The exact rules vary by retailer. For example, one retailer may promise standard delivery by adding transit days based on the distance from the fulfillment location, while another may use a carrier service level. Define these rules with the team responsible for the storefront before enabling the experience.
 
+{% hint style="info" %}
+This page covers the pre-purchase estimate shown on the storefront. Once an order is placed, HotWax Commerce records an estimated ship date and estimated delivery date on the order itself — see [Order Estimated Ship & Delivery Dates](order-estimated-ship-delivery-dates.md).
+{% endhint %}
+
 ## How the date is calculated
 
 The storefront follows this sequence when a shopper checks an estimated delivery date:

--- a/documents/learn-hotwax-oms/how-to-guides/order-estimated-ship-delivery-dates.md
+++ b/documents/learn-hotwax-oms/how-to-guides/order-estimated-ship-delivery-dates.md
@@ -1,0 +1,51 @@
+---
+description: >-
+  HotWax Commerce populates an estimated ship date and estimated delivery date
+  on every order ship group that requires fulfillment, using the promise dates
+  Shopify provides or computing them from configurable SLAs.
+---
+
+# Order Estimated Ship & Delivery Dates
+
+Every sales order ship group that requires fulfillment carries two estimated dates from the moment the order is created:
+
+* **Estimated Ship Date** — when the ship group is expected to leave a fulfillment location.
+* **Estimated Delivery Date** — when it is expected to arrive at the customer.
+
+Ship groups that do not require fulfillment — POS cash sales and order items that arrive already fulfilled — are skipped. Both dates apply to orders imported in real time and to historical orders brought in through bulk sync, so reporting stays consistent across the full order history.
+
+{% hint style="info" %}
+These dates are recorded on the order **after** it is placed. For the pre-purchase estimate a shopper sees on the storefront before ordering, see [Configure estimated delivery dates](configure-estimated-delivery-dates.md) — that experience is calculated live by the storefront and follows its own rules.
+{% endhint %}
+
+## Where the Dates Come From
+
+HotWax Commerce fills each date from the most authoritative source available. A value provided by an external system always wins over a value computed internally.
+
+1. **Dates supplied by the channel.** When Shopify provides delivery promise data on an order's fulfillment orders — for example through Shop Promise or checkout delivery options — HotWax Commerce records the promised fulfillment window on the ship group:
+   * `fulfillBy`, the deadline by which Shopify expects the items to be fulfilled, becomes the ship group's **Ship By** date (the ceiling of the fulfillment window). When it is present, it is also used directly as the **Estimated Ship Date**.
+   * `fulfillAt`, the moment the items become fulfillable — for example a scheduled fulfillment — becomes the **Ship After** date (the floor of the window).
+   * The latest promised arrival time from Shopify's delivery method becomes the **Estimated Delivery Date**.
+2. **Computed defaults.** When the channel does not provide a promise, HotWax Commerce computes the dates:
+   * **Estimated Ship Date** = the ship SLA (in days) added to the moment the ship group becomes actionable — the order date, or the Ship After date when that is later. A ship group that only becomes fulfillable next week still gets its full SLA after that point.
+   * **Estimated Delivery Date** = Estimated Ship Date plus the transit days configured on the carrier shipment method. If no transit days are configured, the delivery date is left empty rather than guessed.
+
+{% hint style="info" %}
+When one ship group contains items from multiple Shopify fulfillment orders, HotWax Commerce keeps the narrowest window that satisfies all of them: the earliest `fulfillBy` and the latest `fulfillAt`. Cancelled fulfillment orders are ignored; closed ones are still read on historical orders so past promise data is preserved.
+{% endhint %}
+
+## Configure the Ship SLA
+
+The ship SLA is read from the **Default Days To Ship** field on the facility that holds the ship group:
+
+* **Brokering queue** — unbrokered ship groups sit in the brokering queue, which is itself a facility. HotWax Commerce seeds its Default Days To Ship to **1**, meaning any order waiting for brokering is expected to ship within a day of becoming actionable. Change this value to change the default promise for all incoming orders.
+* **Fulfillment locations** — a ship group already assigned to a store or warehouse uses that facility's own Default Days To Ship, so locations with different processing speeds can carry different SLAs.
+* When the facility has no value, HotWax Commerce falls back to **1 day**. A value of **0** is valid and means same-day shipping.
+
+## Configure Carrier Transit Days
+
+Transit time comes from the **Delivery Days** field on the carrier shipment method (the combination of carrier and shipment method on the order). This is the same field the order routing engine uses for its *Shipping method* sort, so populating it improves both delivery estimates and brokering behavior.
+
+{% hint style="warning" %}
+Estimated dates are only defaulted when they are empty. Integrations that supply their own estimated ship or delivery dates on the order payload keep their values — HotWax Commerce never overwrites a date provided by an external system.
+{% endhint %}

--- a/documents/learn-hotwax-oms/how-to-guides/order-estimated-ship-delivery-dates.md
+++ b/documents/learn-hotwax-oms/how-to-guides/order-estimated-ship-delivery-dates.md
@@ -2,50 +2,50 @@
 description: >-
   HotWax Commerce populates an estimated ship date and estimated delivery date
   on every order ship group that requires fulfillment, using the promise dates
-  Shopify provides or computing them from configurable SLAs.
+  Shopify provides or computing them from configurable service-level agreements (SLAs).
 ---
 
-# Order Estimated Ship & Delivery Dates
+# Order estimated ship and delivery dates
 
 Every sales order ship group that requires fulfillment carries two estimated dates from the moment the order is created:
 
-* **Estimated Ship Date** — when the ship group is expected to leave a fulfillment location.
-* **Estimated Delivery Date** — when it is expected to arrive at the customer.
+* `Estimated Ship Date`: When the ship group is expected to leave a fulfillment location.
+* `Estimated Delivery Date`: When it is expected to arrive at the customer.
 
-Ship groups that do not require fulfillment — POS cash sales and order items that arrive already fulfilled — are skipped. Both dates apply to orders imported in real time and to historical orders brought in through bulk sync, so reporting stays consistent across the full order history.
+Ship groups that do not require fulfillment, such as POS cash sales and order items that arrive already fulfilled, are skipped. Both dates apply to orders imported in real time and to historical orders brought in through bulk sync, so reporting stays consistent across the full order history.
 
 {% hint style="info" %}
-These dates are recorded on the order **after** it is placed. For the pre-purchase estimate a shopper sees on the storefront before ordering, see [Configure estimated delivery dates](configure-estimated-delivery-dates.md) — that experience is calculated live by the storefront and follows its own rules.
+These dates are recorded on the order **after** it is placed. For the pre-purchase estimate a shopper sees on the storefront before ordering, see [Configure estimated delivery dates](configure-estimated-delivery-dates.md). That experience is calculated live by the storefront and follows its own rules.
 {% endhint %}
 
-## Where the Dates Come From
+## Where the dates come from
 
 HotWax Commerce fills each date from the most authoritative source available. A value provided by an external system always wins over a value computed internally.
 
-1. **Dates supplied by the channel.** When Shopify provides delivery promise data on an order's fulfillment orders — for example through Shop Promise or checkout delivery options — HotWax Commerce records the promised fulfillment window on the ship group:
-   * `fulfillBy`, the deadline by which Shopify expects the items to be fulfilled, becomes the ship group's **Ship By** date (the ceiling of the fulfillment window). When it is present, it is also used directly as the **Estimated Ship Date**.
-   * `fulfillAt`, the moment the items become fulfillable — for example a scheduled fulfillment — becomes the **Ship After** date (the floor of the window).
-   * The latest promised arrival time from Shopify's delivery method becomes the **Estimated Delivery Date**.
+1. **Dates supplied by the channel.** When Shopify provides delivery promise data on an order's fulfillment orders, such as through Shop Promise or checkout delivery options, HotWax Commerce records the promised fulfillment window on the ship group:
+   * `fulfillBy`, the deadline by which Shopify expects the items to be fulfilled, becomes the ship group's `Ship By` date (the ceiling of the fulfillment window). When it is present, it is also used directly as the `Estimated Ship Date`.
+   * `fulfillAt`, the moment the items become fulfillable, such as a scheduled fulfillment, becomes the `Ship After` date (the floor of the window).
+   * The latest promised arrival time from Shopify's delivery method becomes the `Estimated Delivery Date`.
 2. **Computed defaults.** When the channel does not provide a promise, HotWax Commerce computes the dates:
-   * **Estimated Ship Date** = the ship SLA (in days) added to the moment the ship group becomes actionable — the order date, or the Ship After date when that is later. A ship group that only becomes fulfillable next week still gets its full SLA after that point.
-   * **Estimated Delivery Date** = Estimated Ship Date plus the transit days configured on the carrier shipment method. If no transit days are configured, the delivery date is left empty rather than guessed.
+   * `Estimated Ship Date` = the ship SLA (in days) added to the moment the ship group becomes actionable (the order date, or the `Ship After` date when that is later). A ship group that only becomes fulfillable next week still gets its full SLA after that point.
+   * `Estimated Delivery Date` = `Estimated Ship Date` plus the transit days configured on the carrier shipment method. If no transit days are configured, the delivery date is left empty rather than guessed.
 
 {% hint style="info" %}
-When one ship group contains items from multiple Shopify fulfillment orders, HotWax Commerce keeps the narrowest window that satisfies all of them: the earliest `fulfillBy` and the latest `fulfillAt`. Cancelled fulfillment orders are ignored; closed ones are still read on historical orders so past promise data is preserved.
+When one ship group contains items from multiple Shopify fulfillment orders, HotWax Commerce keeps the narrowest window that satisfies all of them: the earliest `fulfillBy` and the latest `fulfillAt`. Canceled fulfillment orders are ignored; closed ones are still read on historical orders so past promise data is preserved.
 {% endhint %}
 
-## Configure the Ship SLA
+## Configure the ship SLA
 
-The ship SLA is read from the **Default Days To Ship** field on the facility that holds the ship group:
+The ship SLA is read from the `Default Days To Ship` field on the facility that holds the ship group:
 
-* **Brokering queue** — unbrokered ship groups sit in the brokering queue, which is itself a facility. HotWax Commerce seeds its Default Days To Ship to **1**, meaning any order waiting for brokering is expected to ship within a day of becoming actionable. Change this value to change the default promise for all incoming orders.
-* **Fulfillment locations** — a ship group already assigned to a store or warehouse uses that facility's own Default Days To Ship, so locations with different processing speeds can carry different SLAs.
-* When the facility has no value, HotWax Commerce falls back to **1 day**. A value of **0** is valid and means same-day shipping.
+* **Brokering queue**: Unbrokered ship groups sit in the brokering queue, which is itself a facility. HotWax Commerce seeds its `Default Days To Ship` to 1, meaning any order waiting for brokering is expected to ship within a day of becoming actionable. Change this value to change the default promise for all incoming orders.
+* **Fulfillment locations**: A ship group already assigned to a store or warehouse uses that facility's own `Default Days To Ship`, so locations with different processing speeds can carry different SLAs.
+* When the facility has no value, HotWax Commerce falls back to 1 day. A value of 0 is valid and means same-day shipping.
 
-## Configure Carrier Transit Days
+## Configure carrier transit days
 
-Transit time comes from the **Delivery Days** field on the carrier shipment method (the combination of carrier and shipment method on the order). This is the same field the order routing engine uses for its *Shipping method* sort, so populating it improves both delivery estimates and brokering behavior.
+Transit time comes from the `Delivery Days` field on the carrier shipment method (the combination of carrier and shipment method on the order). This is the same field the order routing engine uses for its `Shipping method` sort, so populating it improves both delivery estimates and brokering behavior.
 
 {% hint style="warning" %}
-Estimated dates are only defaulted when they are empty. Integrations that supply their own estimated ship or delivery dates on the order payload keep their values — HotWax Commerce never overwrites a date provided by an external system.
+Estimated dates are only defaulted when they are empty. Integrations that supply their own estimated ship or delivery dates on the order payload keep their values. HotWax Commerce never overwrites a date provided by an external system.
 {% endhint %}


### PR DESCRIPTION
Part of hotwax/hotwax-shopify-oms-bridge#297 (estimated ship & delivery dates on order ship groups).

## What

New how-to page **Order Estimated Ship & Delivery Dates** under Learn HotWax OMS → How-To Guides, documenting the dates recorded on order ship groups at creation:

- Source precedence: external values always win (Shopify fulfillment-order promises — `fulfillBy` = ship-by ceiling, `fulfillAt` = ship-after floor, delivery-method window → estimated delivery), computed defaults fill the gaps.
- Computed logic: SLA clock starts when the group becomes actionable (`max(order date, ship-after)` + facility **Default Days To Ship**); delivery = estimated ship + carrier **Delivery Days**; empty when no transit is configured.
- Configuration: brokering-queue facility seeded to a 1-day SLA (override per deployment), per-facility SLAs, carrier Delivery Days (shared with the routing "Shipping method" sort).
- Scope: fulfillment-required ship groups only (POS cash sales / already-fulfilled items skipped); applies to real-time and bulk/historical imports.

The existing [Configure estimated delivery dates](documents/learn-hotwax-oms/how-to-guides/configure-estimated-delivery-dates.md) page covers the *pre-purchase storefront* estimate — a different feature. Both pages now carry a cross-link hint so readers land on the right one.

Feature PRs: hotwax/oms#779 · hotwax/mantle-shopify-connector#391

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1828