### PR TITLE
Add order splitting demo video

### DIFF
--- a/documents/retail-operations/orders/order-routing/additional-settings.md
+++ b/documents/retail-operations/orders/order-routing/additional-settings.md
@@ -47,6 +47,6 @@ To optimize inventory usage and fulfillment speed, retailers often split orders 
 
 Once the threshold is set, orders will only be split if the value of the items meets or exceeds the threshold, ensuring more efficient shipping and reducing losses on low-value shipments.
 
-{% embed url="https://youtu.be/GQU6wyNI4kw" %}
-Set Brokering Shipment Threshold
+{% embed url="https://drive.google.com/file/d/1u6Y_aeR1NKF0iY-xrN5IJyMXzDbj-QKy/view?usp=drive_link" %}
+Order Splitting Controls
 {% endembed %}


### PR DESCRIPTION
## What changed
- Replaced the threshold-only video in Additional Settings with the latest Order Splitting Controls demo from Drive.

## Why
- Gives readers a focused visual explanation of shipment thresholds and order-splitting behavior alongside the existing written guidance.

## Validation
- Confirmed the embed uses GitBook syntax and the Drive video link.