### PR TITLE
Add inventory cycle count demo video

### DIFF
--- a/documents/store-operations/cycle-count/README.md
+++ b/documents/store-operations/cycle-count/README.md
@@ -9,3 +9,7 @@ When the store associate or manager logs into the application, all assigned cycl
 * [Review counts at the store before submitting for review](count-progress-review.md)
 * Review and approve variances at head office
 * [Go back and review old counts and export](../../retail-operations/inventory/cycle-count/closed.md)
+
+{% embed url="https://drive.google.com/file/d/1D-DbMBTo41v_OKKyuE_TXzQHcni1FSt_/view?usp=drive_link" %}
+Inventory Cycle Count
+{% endembed %}


### PR DESCRIPTION
## What changed
- Added the Inventory Cycle Count demo to the Store Operations Cycle Count overview.

## Why
- Gives associates and managers a visual overview of directed and full count workflows before opening the detailed guides.

## Validation
- Confirmed the embed uses GitBook syntax and the Drive video link.