### PR TITLE
gorjana: correct three stale integration claims (code-verified)

### DIFF
--- a/gorjana/flows/inventory/Kit-Inventory-Computation.md
+++ b/gorjana/flows/inventory/Kit-Inventory-Computation.md
@@ -2,7 +2,7 @@
 HotWax calculates bundle inventory by integrating with Shopify for parent product details and NetSuite for component data and inventory levels. It then updates Shopify with the available bundle inventory.
 ## <a name="_j0ftm2y1mqd0"></a>**Key Processes in Inventory Management**
 ### <a name="_soogoxbajth7"></a>**1. Daily Inventory Sync from NetSuite**
-NetSuite provides a daily inventory feed that includes details about kits (bundle products). This information is pulled from a saved search query called "customsearch\_export\_inventory\_item," which generates a CSV file listing products and their inventory.
+NetSuite provides a daily inventory feed with component and product inventory levels. This feed is pulled from a saved search query called "customsearch\_export\_inventory\_item," which generates a CSV file listing products and their inventory. The kit-to-component makeup is delivered separately, by the saved search "customsearch\_hc\_exp\_kit\_component" imported through the "Import KIT Component" job. NetSuite does not send a kit inventory level; HotWax computes each kit's available inventory from its component levels.
 ### <a name="_ibak2ws84yns"></a>**2. Inventory Calculation** 
 The "Bulk Recent Kit Product Inventory Setup" job sets kit inventory to the lowest stock level of its components at a given location. For example at the Williamsburg store:
 
@@ -11,7 +11,7 @@ The "Bulk Recent Kit Product Inventory Setup" job sets kit inventory to the lowe
 
 Kit ATP = 7. After fulfillment, ATP and QOH for the kit and components are reduced.
 ### <a name="_shqnydc5lp10"></a>**3. Shopify Inventory Push**
-Set the product store setting in Shopify to "N" to enable HotWax Commerce to manage inventory updates to Shopify. The **hard\_sync** service pushes updates, ensuring accurate inventory synchronization between HotWax Commerce and Shopify.
+Set the product store setting in Shopify to "N" to enable HotWax Commerce to manage inventory updates to Shopify. The "Upload inventory" job posts absolute on-hand quantities to Shopify (a full reset), and the "Upload recent inventory change" job posts recent changes. Together they keep inventory synchronized between HotWax Commerce and Shopify.
 
 
 

--- a/gorjana/flows/transfer-orders/README.md
+++ b/gorjana/flows/transfer-orders/README.md
@@ -3,7 +3,7 @@
 ## Receive in HotWax
 Transfer order names will be shown in the receiving app and highlight the native field details from NetSuite like transfer order name.
 
-Because Gorjana uses ShipHawk, it's possible that the custom table "ShipHawk Package Items" will need to be used when importing fulfilled TOs into HotWax for receiving.
+Warehouse-fulfilled transfer orders import into HotWax through NetSuite's item-fulfillment feed, and HotWax matches each product by its identifier. The "ShipHawk Package Items" table is not used in this receiving-import path. ShipHawk is used for shipping and carrier recording only.
 
 ## Fulfill in HotWax
 Transfer orders that are fulfilled from HotWax will be posted as multiple fulfillments in NetSuite when fulfilled in multiple shipments.


### PR DESCRIPTION
## What this is

The first output of a documentation reconciliation exercise: published implementation docs checked claim-by-claim against current code, with corrections capped at each doc's existing disclosure level (this is a public repo, so no correction names an internal mechanism the doc did not already name).

Three stale claims in gorjana docs, each verified against gorjana's deployed components and the NetSuite/Shopify connectors:

1. **Kit inventory — daily feed scope.** The daily NetSuite inventory feed does not carry kit makeup. Kit-to-component mapping arrives separately, via the `customsearch_hc_exp_kit_component` saved search and the "Import KIT Component" job. HotWax computes kit availability from component levels. (The doc already named the sibling saved search, so this stays at the same disclosure level.)
2. **Kit inventory — Shopify push service.** There is no `hard_sync` service in the code. The Shopify push runs through the "Upload inventory" job (full on-hand reset) and the "Upload recent inventory change" job.
3. **Transfer orders — ShipHawk.** Dropped the speculative "it's possible the ShipHawk Package Items table will need to be used" for TO receiving import. Warehouse-fulfilled transfer orders import through NetSuite's item-fulfillment feed, with the product matched by its identifier. ShipHawk is used for shipping and carrier recording only.

## Scope and what was deliberately held back

This exercise reconciled 11 docs (gorjana + krewe). This PR carries only the three fixes that gorjana's on-disk deployed component lets me verify end to end. Held for follow-up, not guessed:

- The facility external-mappings UI label correction (the exact modal is not confirmable from backend code — needs a quick check against the live app).
- Three krewe inventory/receiving corrections. krewe's deployed component is not available to verify against, and one of them (purchase-order vs transfer-order reconciliation scope) is an open product question, not a settled fact.
- The Happiness Guaranteed doc, which is an early design proposal that never shipped as written (12 of 27 claims stale). It needs a rewrite, not line patches — flagged for a separate decision.