### PR TITLE
Document NetSuite return lifecycle and store credit accounting

### DIFF
--- a/documents/learn-netsuite/integration-flows/returns/README.md
+++ b/documents/learn-netsuite/integration-flows/returns/README.md
@@ -18,7 +18,7 @@ A return merchandise authorization (RMA) is represented by a NetSuite `Return Au
 The exact jobs, transport, schedules, and mappings vary by implementation. This page describes the NetSuite record pattern used when a HotWax Commerce integration is configured to synchronize returns.
 {% endhint %}
 
-This page focuses on merchandise returns against NetSuite Sales Orders and Invoices that use the RMA cycle. Some implementations can post a direct `Credit Memo` and `Customer Refund` when no return authorization or physical receipt is required. In the HotWax integration pattern documented here, returns against Cash Sales use a `Cash Refund` instead of the RMA, Credit Memo, and Customer Refund lifecycle.
+This page focuses on merchandise returns against NetSuite Sales Orders and Invoices that use the RMA cycle. Some implementations can post a direct `Credit Memo` and `Customer Refund` when no return authorization or physical receipt is required. Depending on the configured record flow, returns against Cash Sales can use a `Cash Refund` instead of the RMA, Credit Memo, and Customer Refund lifecycle.
 
 ## Understand the NetSuite record chain
 
@@ -131,6 +131,8 @@ For an original-payment refund, the integration:
 3. Creates one or more `Customer Refund` records for the refunded amounts
 4. Applies the Credit Memo to the Customer Refund records
 
+Saving a Customer Refund applies the Credit Memo. NetSuite returns every created Customer Refund ID, and HotWax Commerce must persist each one as a settlement checkpoint before acknowledging the settlement. Before retrying, verify those checkpoints in NetSuite instead of creating another refund blindly.
+
 The Credit Memo moves from open to fully applied when the entire returned value has been refunded or applied elsewhere.
 
 For split settlements, only the original-payment portion creates a Customer Refund. The remaining Credit Memo value can be applied to a store-credit or exchange Invoice.
@@ -187,7 +189,8 @@ sequenceDiagram
 
     alt Refund original payment
         HotWax->>NetSuite: Create Credit Memo from RMA
-        HotWax->>NetSuite: Create Customer Refund and apply credit
+        HotWax->>NetSuite: Create one or more Customer Refunds and apply Credit Memo
+        NetSuite-->>HotWax: Customer Refund ID for each created refund
     else Issue store credit
         Commerce-->>Customer: Issue store credit
         Commerce-->>HotWax: Send credit transaction ID
@@ -215,6 +218,7 @@ HotWax Commerce tracks the NetSuite records required for each return:
 | Return authorized | RMA ID |
 | Merchandise received | Item Receipt ID |
 | Returned value recorded | Credit Memo ID |
+| Original-payment refund created | Customer Refund IDs |
 | Store-credit Invoice created | Invoice ID |
 
 A return is fully synchronized only when every record required for its outcome exists and the Credit Memo application is verified in NetSuite when required. An export attempt, queued request, or stored Invoice ID does not prove that the application succeeded.
@@ -228,6 +232,6 @@ Review these conditions during reconciliation:
 * The store-credit Invoice amount matches the customer-facing credit issued
 * The Credit Memo and target Invoice use the same customer so NetSuite can apply them
 * The Credit Memo application in NetSuite matches the required amount
-* Every retry reuses persisted NetSuite IDs
+* Before a retry creates another refund, verify every persisted Customer Refund ID in NetSuite
 
 For the return feed contract, see [Returns financial feed](../../../integrate-with-hotwax/api/returns/returns-financial-feed.md).

--- a/documents/learn-netsuite/integration-flows/returns/README.md
+++ b/documents/learn-netsuite/integration-flows/returns/README.md
@@ -1,250 +1,233 @@
 ---
-description: Learn about returns in Shopify, Loop, NetSuite and HotWax Commerce.
+description: >-
+  Learn how HotWax Commerce synchronizes return authorizations, item receipts,
+  credit memos, refunds, and store credit with NetSuite.
 ---
 
 # Returns
 
-In omnichannel retailing, retailers provide customers with the options for online returns as well as in-store returns.
+When an implementation uses the RMA-based return cycle, HotWax Commerce converts a return into linked operational and financial records in NetSuite. The integration keeps three milestones separate:
 
-## Web Returns with Loop
+1. Authorize the return
+2. Record received inventory when merchandise comes back
+3. Settle the customer value through a refund, store credit, or exchange
 
-Customers can initiate online returns for both online and in-store purchases.
+A return merchandise authorization (RMA) is represented by a NetSuite `Return Authorization`. Separating the RMA, inventory receipt, and financial settlement prevents inventory or accounting records from moving before the return is ready.
 
-* **Buy Online Return Online (BORO)**: Customers initiate online returns for their eCommerce orders.
-* **Buy In-Store Return Online (BISRO)**: Customers initiate online returns for their in-store purchases.
-* **Endless Aisle Return Online (EARO)**: Customers initiate online returns for their in-store ordered items which they received home delivery for.
+{% hint style="info" %}
+The exact jobs, transport, schedules, and mappings vary by implementation. This page describes the NetSuite record pattern used when a HotWax Commerce integration is configured to synchronize returns.
+{% endhint %}
 
-Retailers we work with use Shopify as their eCommerce platform, NetSuite as their ERP system, Loop as their RMS, and HotWax Commerce as their OMS. This returns management workflow involves downloading returns data, creating Return Merchandise Authorizations (RMAs), processing Item Receipt records, and creating Customer Refunds.
+This page focuses on merchandise returns against NetSuite Sales Orders and Invoices that use the RMA cycle. Some implementations can post a direct `Credit Memo` and `Customer Refund` when no return authorization or physical receipt is required. In the HotWax integration pattern documented here, returns against Cash Sales use a `Cash Refund` instead of the RMA, Credit Memo, and Customer Refund lifecycle.
 
-<figure><img src="../../.gitbook/assets/online-returns-loop.png" alt=""><figcaption><p>Sync web returns to NetSuite</p></figcaption></figure>
+## Understand the NetSuite record chain
 
-Whenever an online return is processed in NetSuite through HotWax it follows these steps:
-
-1. The In Progress return is posted to NetSuite as an RMA against the order the customer is returning
-2. The RMA is received at the warehouse
-3. The receipt confirmation issues a refund to the customer
-
-This document will break down exactly how HotWax integrates with NetSuite to help execute each of these steps.
-
-#### 1. Export and Transform Returns Data from HotWax Integration Platform
-
-A job in HotWax Commerce Integration Platform captures in progress returns from HotWax Commerce OMS or another online returns platform, like Loop, and places them at a designated SFTP location. This enables NetSuite to access and process the data for creating RMAs for further processing.
-
-**SFTP Locations**
-
-Example for Loop returns:
-
-```
-/home/{sftp-username}/netsuite/loop-return/create
+```mermaid
+flowchart LR
+    source["Commerce or returns system"] -->|"Return request and outcome"| hotwax["HotWax Commerce"]
+    hotwax -->|"Create or update"| rma["Return Authorization (RMA)"]
+    rma -.->|"When merchandise is received"| receipt["Item Receipt"]
+    receipt --> inventory["Inventory disposition"]
+    rma -->|"When the return is completed"| memo["Credit Memo"]
+    memo --> outcome{"Settlement outcome"}
+    outcome -->|"Original payment"| refund["Customer Refund"]
+    outcome -->|"Store credit"| invoice["Store-credit Invoice"]
+    outcome -->|"Exchange"| replacement["Replacement order and Invoice"]
+    refund -->|"Apply returned value"| settled["Settlement recorded"]
+    invoice -->|"Apply Credit Memo"| settled
+    replacement -->|"Use Credit Memo according to configuration"| settled
 ```
 
-#### 2. Import Returns Data in NetSuite
+The `Return Authorization` approves the return. The optional `Item Receipt` records the physical inventory movement. The `Credit Memo` records the returned value and is then settled according to the outcome.
 
-Every 15 minutes, a scheduled SuiteScript in NetSuite runs to check for new return files at the SFTP location.
+## Meet the synchronization prerequisites
 
-If a new RMA JSON file is found, the NetSuite SuiteScript reads and processes the file. An RMA is then created in NetSuite and marked as **Pending Receipt.**
+Before synchronizing a return, confirm that the integration can resolve:
 
-The newly created RMA is linked to the original sales order. This offers traceability and provides warehouse teams with advance notice that the order item will be returned.
+* A stable source return ID
+* The original HotWax order and return lines
+* The NetSuite Sales Order and line IDs, when the original order is available
+* The customer, subsidiary, location, department, item, tax, and payment mappings
+* The expected inventory disposition for every return line
+* The settlement method and amount
+* A configured NetSuite item for store-credit posting, when store credit is supported
 
-**SuiteScript**
+Returns and refunds may arrive as separate source events. The integration must use explicit return, refund, order, and line references rather than assume that every return contains a refund or that every refund contains a return.
 
-```
-HC_SC_CreateLoopReturn.js
-```
+For Shopify return intake, see [Import returns from Shopify](../../../learn-shopify/shopify-integration/order-return/import-returns-from-shopify.md).
 
-#### 3. Process and Export Item Receipts Records
+## Synchronize the return lifecycle
 
-After a few days, when the customer's returned item is physically received at the warehouse, the following actions take place:
+### 1. Capture the return
 
-* An Item Receipt record is created and linked to the RMA.
-* Inventory is restocked, and the corresponding inventory count is increased in NetSuite.
-* The RMA status updates from **Pending Receipt** to **Pending Refund**.
+HotWax Commerce receives the return from the commerce or returns system. The return record identifies:
 
-As soon as the Item Receipt record is created in NetSuite, a CSV file is generated containing Loop’s return ID for reference. This file is then placed at the designated SFTP location.
+* The source return and original order
+* The returned items and quantities
+* The customer
+* The return status and completion date
+* The restock or no-restock decision
+* The receiving location
+* The refund, store-credit, or exchange outcome
 
-This step is important for completing the return process in Loop, let’s see how in the next steps.
+The return can remain in progress while merchandise is in transit or awaiting inspection. Financial settlement begins when the source return reaches its configured completion point and the settlement details are available.
 
-**SuiteScript**
+### 2. Create the Return Authorization
 
-```
-HC_MR_ExportLoopReturnProcess.js
-```
+When the original NetSuite Sales Order is available, the integration transforms that Sales Order into a `Return Authorization`. This preserves the relationship to the original customer, items, prices, taxes, and selling location.
 
-**SFTP Locations**
+For a blind return without an original order, the implementation can create a standalone `Return Authorization`. The return needs explicit customer, location, tax, and line mappings because NetSuite cannot inherit them from an original Sales Order.
 
-```
-/home/{sftp-username}/netsuite/loop-return/process-return
-```
+HotWax Commerce saves the NetSuite RMA ID and line IDs before continuing. Retries reuse these identifiers instead of creating another RMA.
 
-#### 7. Import Item Receipt Records
+### 3. Record received merchandise
 
-A job in HotWax Commerce Integration Platform runs every 5 minutes to check for new CSV files received at the SFTP location. If any new files are identified, the job extracts the Loop return IDs from the file and subsequently triggers the [“Process Return” API](https://docs.loopreturns.com/api-reference/latest/return-actions/process-return).
+When merchandise is physically accepted, the integration transforms the RMA into an `Item Receipt` for the received quantities and destination location.
 
-**SFTP Locations**
+* Sellable merchandise moves into the configured sellable inventory location
+* Damaged merchandise can move into a separate non-sellable location
+* No-restock outcomes can skip the Item Receipt or use configured inventory adjustment logic
+* Partial receipts leave the unresolved RMA quantities open
 
-```
-/home/{sftp-username}/netsuite/loop-return/process-return
-```
+The RMA authorizes the return but does not move inventory by itself. The `Item Receipt` records the physical inventory movement.
 
-#### 8. Close Returns in Loop
+{% hint style="warning" %}
+A Credit Memo created from an RMA does not restock inventory. A standalone Credit Memo can affect inventory. Do not combine an Item Receipt with a standalone Credit Memo that restocks the same units unless that double movement is intentional.
+{% endhint %}
 
-The Process Return API triggers multiple actions in Loop based on the fetched Loop return IDs:
+The timing of receipt and settlement depends on the return policy. A return shipped to a warehouse may wait for receipt before completion. Merchandise already held by a store or a no-receipt outcome can become ready for settlement earlier.
 
-* The RMA status is updated from **Open** to **Closed**.
-* As soon as the RMA in Loop is marked as Closed, multiple actions take place:
-  * If the customer opted to receive a refund on their original payment method, Loop triggers Shopify to process the refund.
-  * If the customer selected "Return for Store Credit," Loop automatically issues a gift card to the customer for the corresponding amount.
-  * If the customer selected "Exchange," Loop creates a new exchange order in Shopify.
+### 4. Post the financial outcome
 
-#### 9. Process Refunds to Customers
+After the return is completed, the integration creates a `Credit Memo` for the returned value. The next record depends on how the customer was compensated.
 
-Shopify processes the customer refund using the original payment method, updating the return status from **In-Progress** to **Returned** in Shopify. At the same time, Shopify syncs the refund details back to Loop.
-
-#### 10. Fetch and Transform Refund Details
-
-HotWax Commerce Integration Platform subscribes to Loop’s webhook to fetch and transform refund details.
-
-**SFTP Locations**
-
-```
-/home/{sftp-username}/netsuite/loop-return/close
-```
-
-#### 11. Transform and Export Refund Details
-
-A flow in HotWax Commerce Integration Platform transforms refund data. The JSON file is then placed at the SFTP location.
-
-The file contains details about Loop return ID, Shopify order ID and the refund amount initiated to the customer.
-
-#### 12. Import Refund Details in NetSuite
-
-A SuiteScript in NetSuite imports the file from the SFTP location, processes the data and triggers multiple actions:
-
-* A Credit Memo is created in Open status and linked to the RMA.
-* A Customer Refund record is automatically created based on the refund method and linked to the Credit Memo.
-* Once the Customer Refund record is created, the Credit Memo is updated from Open to Fully Applied, and the RMA is updated from Pending Refund to Refunded.
-
-**SuiteScript**
-
-```
-HC_SC_CreateLoopReturnRefund.js
+```mermaid
+flowchart TD
+    completed["Return completed"] --> method{"How was the customer compensated?"}
+    method -->|"Original payment method"| refundMemo["Create Credit Memo from RMA"]
+    refundMemo --> customerRefund["Create one or more Customer Refunds"]
+    customerRefund --> applyRefund["Apply Credit Memo to Customer Refunds"]
+    method -->|"Store credit"| issueCredit["Store credit issued in the commerce platform"]
+    issueCredit --> creditMemo["Create Credit Memo from RMA"]
+    creditMemo --> creditInvoice["Create Invoice with the store-credit item"]
+    creditInvoice --> applyInvoice["Apply Credit Memo to Invoice"]
+    method -->|"Exchange or replacement"| exchangeMemo["Create Credit Memo from RMA"]
+    exchangeMemo --> replacementOrder["Create or link the replacement order"]
+    replacementOrder --> exchangeInvoice["Invoice the replacement order"]
+    exchangeInvoice --> applyExchange["Use Credit Memo according to configuration"]
+    applyRefund --> complete["Settlement complete"]
+    applyInvoice --> complete
+    applyExchange --> complete
 ```
 
-#### 13. Sync Completed Returns from Shopify
+The branches use the same returned value but represent different accounting events. A Customer Refund records money returned to the customer. A store-credit Invoice represents the issued credit through the configured store-credit item. An exchange Invoice records the new merchandise supplied to the customer.
 
-A job in HotWax Commerce syncs the newly created Completed returns from Shopify and marks them as Completed in HotWax.
+## Refund the original payment method
 
-**How is returned inventory restocked in HotWax Commerce?**
+For an original-payment refund, the integration:
 
-Inventory from returns received in the warehouse is synchronized to HotWax Commerce during its periodic inventory sync with NetSuite. HotWax then also syncs the updated inventory counts of the product to Shopify.
+1. Creates the `Credit Memo` from the RMA
+2. Maps each refunded payment method to a NetSuite refund method
+3. Creates one or more `Customer Refund` records for the refunded amounts
+4. Applies the Credit Memo to the Customer Refund records
 
-Loop also offers the option to restock inventory. However, HotWax recommends disabling this feature in Loop. The reason is that HotWax and NetSuite handle inventory tracking across all locations, while Shopify only maintains a consolidated inventory at its default location.
+The Credit Memo moves from open to fully applied when the entire returned value has been refunded or applied elsewhere.
 
-With this setup, after HotWax restocks the returned inventory from NetSuite during its periodic inventory sync, a corresponding job in HotWax automatically increases the product's inventory count at the default location in Shopify.
+For split settlements, only the original-payment portion creates a Customer Refund. The remaining Credit Memo value can be applied to a store-credit or exchange Invoice.
 
-***
+## Post store credit
 
-### Handling of Exchanges in NetSuite
+The customer-facing store credit is issued in the commerce platform. For example, a Shopify implementation issues store credit to the customer account and sends the issued amount and transaction reference to HotWax Commerce.
 
-When a customer opts for an exchange through Loop, a new exchange order is automatically created in Shopify once the return is closed in Loop. HotWax Commerce downloads these exchange orders from Shopify as regular orders and syncs them to NetSuite. Here's how different exchange scenarios are handled:
+NetSuite mirrors the accounting impact without returning cash:
 
-#### 1. When the exchange order total is less than the original order
+1. Create the `Credit Memo` from the RMA without a Customer Refund for the store-credit portion
+2. Create a separate `Invoice` for the store-credit amount
+3. Add the configured store-credit item to the Invoice
+4. Apply the corresponding Credit Memo amount to the Invoice
 
-* Loop automatically refunds the customer for the price difference and creates a new exchange order in Shopify.
-* HotWax’s Integration Platform captures this refund data and processes it as discussed earlier, transforming it for NetSuite without additional steps.
+The Invoice is the NetSuite accounting representation of the store credit issued in the commerce platform. Applying the Credit Memo balances the Invoice and fully applies that portion of the returned value.
 
-#### 2. When the exchange is for an item of equal value
+{% hint style="warning" %}
+The NetSuite Invoice does not issue customer-facing store credit. The commerce platform issues the credit once and sends its transaction reference to HotWax Commerce. NetSuite then records the financial posting. Reprocessing must reuse the recorded RMA, Credit Memo, and Invoice IDs so it does not create duplicate accounting records.
+{% endhint %}
 
-* The return and exchange data are transformed and synced to NetSuite, as previously discussed.
-* No refund is issued to the customer because the funds from their return are applied to their exchange order.
+## Handle exchanges and replacements
 
-#### 3. When the exchange is for an item of higher value (Upsell)
+An exchange or replacement creates a real new order. The return side still creates an RMA and Credit Memo. Depending on the implementation, the Credit Memo can be referenced by or applied to the Invoice for the new order. When the implementation applies the Credit Memo to the new Invoice:
 
-* Loop includes attribution in the Shopify order notes, indicating that the new exchange order involves an upsell.
-* HotWax recognizes this attribution and processes the order accordingly.
-* To post the additional payment, HotWax creates a Customer Deposit in NetSuite.
+* If the new order costs more, the customer pays the difference and the additional payment is posted separately
+* If both values are equal, the Credit Memo can fully offset the new Invoice
+* If the new order costs less, the remaining Credit Memo value is refunded or applied to a store-credit Invoice
 
-Suppose a customer initiates a return for a $100 item and chooses to exchange it for a $150 product. Loop processes the exchange, and Shopify records the new order with an additional $50 payment. The order notes include the upsell attribution. HotWax reads these notes, identifies the upsell, and generates a Customer Deposit for $50 in NetSuite, helping maintain accurate financial records.
+See [Exchanges](../exchanges/README.md) for the full exchange lifecycle.
 
-***
+## Follow the end-to-end message flow
 
-### Handling Returns for Older Orders
+```mermaid
+sequenceDiagram
+    actor Customer
+    participant Source as Return source
+    participant Commerce as Commerce platform
+    participant HotWax as HotWax Commerce
+    participant NetSuite
 
-Retailers' return policies can vary, ranging from one to several months. To accommodate future returns, HotWax imports historical orders from Shopify. However, some retailers accept returns for orders placed over a year ago. If a retailer starts using HotWax Commerce within that same year and lacks historical orders in the OMS, here’s how HotWax handles such cases:
+    Customer->>Source: Submit return
+    Source->>HotWax: Return, items, disposition, and outcome
+    HotWax->>NetSuite: Create Return Authorization
+    NetSuite-->>HotWax: RMA and line IDs
 
-#### 1. Matching Shopify and NetSuite order IDs
+    opt Merchandise is physically received
+        Source->>HotWax: Receipt and restock decision
+        HotWax->>NetSuite: Create Item Receipt from RMA
+        NetSuite-->>HotWax: Item Receipt ID
+    end
 
-* When return data is received from Loop, HotWax’s Integration Platform first checks the Shopify order ID in the OMS.
-* If a corresponding NetSuite order ID is found, the return process proceeds without interruptions.
-* The RMA is created in NetSuite and linked to the original sales order, maintaining consistency in data and workflows.
+    Source->>HotWax: Complete return and record settlement
 
-#### 2. Fetching older orders from NetSuite
+    alt Refund original payment
+        HotWax->>NetSuite: Create Credit Memo from RMA
+        HotWax->>NetSuite: Create Customer Refund and apply credit
+    else Issue store credit
+        Commerce-->>Customer: Issue store credit
+        Commerce-->>HotWax: Send credit transaction ID
+        HotWax->>NetSuite: Create Credit Memo from RMA
+        HotWax->>NetSuite: Create store-credit Invoice
+        HotWax->>NetSuite: Apply Credit Memo to Invoice
+    else Exchange or replacement
+        Source->>HotWax: Create or link replacement order
+        HotWax->>NetSuite: Create Credit Memo from RMA
+        HotWax->>NetSuite: Synchronize replacement order and Invoice
+        HotWax->>NetSuite: Use Credit Memo according to configuration
+    end
 
-* In some cases, older orders may not be imported into the OMS, but the corresponding records still exist in NetSuite.
-* When no matching NetSuite order ID is found in the OMS, HotWax’s Integration Platform runs a search query in NetSuite using the Shopify order ID to locate the original sales order details.
-
-    Once the original sales order is retrieved from NetSuite, the necessary return details are synced. This step helps ensure that even older orders, which might not have been part of the initial OMS setup, are accurately linked with the RMA and processed.
-
-***
-
-## POS Returns
-
-Customers who live near a brick-and-mortar store or those who prefer to get instant refunds opt for returning their purchases directly in-store.
-
-#### Scenarios where POS returns are accepted
-
-* **Buy In-Store Return In-Store (BISRIS):** Customers return their in-store purchases to a nearby store location.
-* **Buy Online Return In-Store (BORIS):** Customers directly return their online purchases to a nearby store location.
-* **Endless Aisle Return In-Store (EARIS):** Customers return orders made through an endless aisle feature, such as items ordered in-store for home delivery, to a nearby store location.
-
-Retailers we work with, use Shopify POS as their POS system, NetSuite as their ERP system, Loop as their RMS, and HotWax Commerce as their OMS. Some retailers initiate in-store returns using the Loop Returns POS App, while others opt to use their Shopify POS system. Let's see how these two approaches work:
-
-## Synchronizing Shopify POS Returns to NetSuite 
-
-<figure><img src="../../.gitbook/assets/in-store-returns-shopify-pos.png" alt=""><figcaption><p>Sync POS returns to NetSuite using HotWax Commerce</p></figcaption></figure>
-
-Shopify POS in-store returns sync to Credit Memo, and Customer Refunds.
-
-#### 1. Transform and Export Returns Data
-
-A scheduled job in the HotWax Commerce Integration Platform captures and transforms newly created POS returns. The transformed JSON file is placed at a designated SFTP location.
-
-**SFTP Locations**
-
-POS returns:
-
-```
- /home/{sftp-username}/netsuite/pos-return
+    NetSuite-->>HotWax: Credit Memo and Invoice IDs when required
 ```
 
-#### 2. Import POS Returns in NetSuite
+The transport can be event-driven, scheduled, file-based, or API-based. The business checkpoints remain the same even when the technical delivery method changes.
 
-A scheduled SuiteScript in NetSuite reads the JSON file from the SFTP location and triggers the following actions:
+## Reconcile the lifecycle
 
-* A Credit Memo is created in Open status
-* A Customer Refund record is automatically created based on the refund method and linked to the Credit Memo
-* Once the Customer Refund record is created, the Credit Memo is marked as Fully Applied
+HotWax Commerce tracks the NetSuite records required for each return:
 
-Creating a Credit Memo also automatically restocks the inventory in NetSuite. This process helps in maintaining accurate GL accounting and posting, simplifying financial reconciliation.
+| Checkpoint | NetSuite identifier |
+| --- | --- |
+| Return authorized | RMA ID |
+| Merchandise received | Item Receipt ID |
+| Returned value recorded | Credit Memo ID |
+| Store-credit Invoice created | Invoice ID |
 
-**SuiteScript**
+A return is fully synchronized only when every record required for its outcome exists and the Credit Memo application is verified in NetSuite when required. An export attempt, queued request, or stored Invoice ID does not prove that the application succeeded.
 
-```
-HC_SC_CreatePOSReturn.js
-```
+Review these conditions during reconciliation:
 
-#### Handling of Multiple Scenarios
+* The RMA uses the correct customer and original Sales Order
+* Item Receipt quantities and locations match the physical disposition
+* The Credit Memo amount, tax, subsidiary, location, and department match the return
+* Customer Refund records match only the amounts returned to payment methods
+* The store-credit Invoice amount matches the customer-facing credit issued
+* The Credit Memo and target Invoice use the same customer so NetSuite can apply them
+* The Credit Memo application in NetSuite matches the required amount
+* Every retry reuses persisted NetSuite IDs
 
-When returning an item, a customer can also opt to take the exchange item against it. The exchange item may be of higher value than the original item or may be of lesser value. Learn more about how HotWax Commerce handles exchanges on an order.
-
-***
-
-## Synchronizing Loop POS Returns to NetSuite 
-
-<figure><img src="../../.gitbook/assets/pos-returns-sync-to-netsuite-using-loop.png" alt=""><figcaption><p>Sync POS returns to NetSuite using Loop</p></figcaption></figure>
-
-Retailers use the Loop POS app alongside Shopify POS to handle in-store returns and exchanges. Once a return is processed in Loop POS, the data is synced to Shopify.
-
-HotWax Commerce fetches this return data from Shopify, transforms it, and places it at a specific SFTP location. NetSuite then reads the file to create the Credit Memo and Customer Refund, while also restocking the returned inventory.
-
-***
+For the return feed contract, see [Returns financial feed](../../../integrate-with-hotwax/api/returns/returns-financial-feed.md).

--- a/documents/learn-netsuite/synchronization-flows/order-sync/README.md
+++ b/documents/learn-netsuite/synchronization-flows/order-sync/README.md
@@ -4,3 +4,6 @@ description: Documentation for Orders.
 
 # Orders
 
+HotWax Commerce synchronizes customers, order records, and NetSuite identifiers before the order is approved for fulfillment.
+
+After fulfillment, a returned order continues through the [NetSuite returns lifecycle](../../integration-flows/returns/README.md), including the Return Authorization, inventory receipt, and financial settlement.

--- a/documents/learn-netsuite/synchronization-flows/order-sync/README.md
+++ b/documents/learn-netsuite/synchronization-flows/order-sync/README.md
@@ -6,4 +6,4 @@ description: Documentation for Orders.
 
 HotWax Commerce synchronizes customers, order records, and NetSuite identifiers before the order is approved for fulfillment.
 
-After fulfillment, a returned order continues through the [NetSuite returns lifecycle](../../integration-flows/returns/README.md), including the Return Authorization, inventory receipt, and financial settlement.
+After fulfillment, a returned order follows the [NetSuite returns lifecycle](../../integration-flows/returns/README.md) based on its NetSuite transaction type. Returns against Sales Orders can include a `Return Authorization`, optional `Item Receipt`, and financial settlement. Depending on the configured record flow, returns against Cash Sales can use a `Cash Refund` instead of the RMA path.


### PR DESCRIPTION
## Business summary

This PR gives implementation, support, and finance teams a shared, provider-neutral model for synchronizing returns with NetSuite. It separates return authorization, physical inventory receipt, and customer settlement so readers can understand which records are required for refunds, store credit, and exchanges without relying on a customer- or channel-specific workflow.

Closes #1862

## What changed

- Rewrote the canonical NetSuite returns guide around the RMA-based lifecycle.
- Documented Return Authorization, optional Item Receipt, Credit Memo, Customer Refund, Cash Refund, store-credit Invoice, and configurable exchange outcomes.
- Clarified that customer-facing store credit is issued in the commerce platform while NetSuite records the accounting representation through a Credit Memo, configured Invoice, and Credit Memo application.
- Added reconciliation guidance that distinguishes stored identifiers from proof that NetSuite completed the required application.
- Added three Mermaid diagrams covering the record chain, settlement decision, and end-to-end message flow.
- Added a post-fulfillment returns link to the NetSuite order-sync landing page.

## Business impact

The generalized lifecycle reduces ambiguity during implementation and reconciliation. It helps teams avoid duplicate inventory movement, unconditional Customer Refund assumptions, duplicate accounting records, and incomplete store-credit settlement checks.

## Validation

- `markdownlint-cli2`: 0 issues
- `codespell`: passed
- `git diff --check`: passed
- Relative documentation links: verified
- All three Mermaid diagrams: rendered successfully with the Mermaid engine

## Preview note

The Mermaid fences are syntactically valid, but the repository does not prove that the Mermaid integration is enabled for the Learn NetSuite GitBook space. Validate the diagrams in the GitBook branch preview before publication.