### PR TITLE
Route NetSuite settings links to published GitBook pages

### DIFF
--- a/documents/system-admin/administration/company/configure-netsuite-setting.md
+++ b/documents/system-admin/administration/company/configure-netsuite-setting.md
@@ -23,7 +23,7 @@ The page contains three areas:
 5. Update the connection only when the integration team provides approved values.
 6. Save the change and verify the next expected file transfer.
 
-See [Set up SFTP](../../../learn-netsuite/netsuite-deployment/sdf-bundle/setup-sftp.md) for the NetSuite-side requirements.
+See [Set up SFTP](https://docs.hotwax.co/documents/learn-netsuite/netsuite-deployment/sdf-bundle/setup-sftp) for the NetSuite-side requirements.
 
 ## Select the Product Store
 
@@ -32,7 +32,7 @@ See [Set up SFTP](../../../learn-netsuite/netsuite-deployment/sdf-bundle/setup-s
 3. Save the selection.
 4. Confirm the Product Store on the NetSuite landing page.
 
-Review the related [NetSuite Product Store settings](../../../learn-netsuite/netsuite-deployment/prerequisite-syncs/productstore-settings.md) before activation.
+Review the related [NetSuite Product Store settings](https://docs.hotwax.co/documents/learn-netsuite/netsuite-deployment/prerequisite-syncs/productstore-settings) before activation.
 
 ## Configure inventory variances
 
@@ -58,7 +58,7 @@ Unmapped variance reasons can prevent an inventory adjustment from posting corre
 3. Select the matching NetSuite payment method.
 4. Save the mapping.
 
-See [NetSuite payment method mappings](../../../learn-netsuite/synchronization-flows/integration-mappings/payment-methods.md) for integration context.
+See [NetSuite payment method mappings](https://docs.hotwax.co/documents/learn-netsuite/synchronization-flows/integration-mappings/payment-methods) for integration context.
 
 ## Configure price levels and discounts
 
@@ -67,7 +67,7 @@ See [NetSuite payment method mappings](../../../learn-netsuite/synchronization-f
 3. Select the matching NetSuite price level or discount item.
 4. Save the mapping.
 
-See [NetSuite price levels](../../../learn-netsuite/synchronization-flows/integration-mappings/price-levels.md) for deployment requirements.
+See [NetSuite price levels](https://docs.hotwax.co/documents/learn-netsuite/synchronization-flows/integration-mappings/price-levels) for deployment requirements.
 
 ## Map departments
 


### PR DESCRIPTION
Closing this approach after broader repository analysis.

The repository-relative links are the correct source representation. The GitBook site is split into separate spaces rooted at individual `documents/<guide>` directories, so cross-space relative paths fall outside the current space’s sync root and GitBook converts them to GitHub URLs.

The authoritative branch contains 81 such cross-space links across 46 pages and 17 guide-to-guide pairs. Hardcoding published URLs page-by-page would couple the source to current site routing and is not the right systemic solution. The fix should be applied at the GitBook space/publishing layer while preserving repo-relative source links.