### PR TITLE
Update README to remove exclusion note around composer and workforce

### DIFF
--- a/documents/system-admin/administration/company/README.md
+++ b/documents/system-admin/administration/company/README.md
@@ -39,5 +39,3 @@ Use these guides for regular administration:
 * [Manage facilities](../facilities/manage-facility-details.md)
 * [Manage users](../users/manage-user.md)
 * [Review Company settings](settings.md)
-
-This manual excludes Composer and Workforce. The product team must confirm their audience and publication status before adding operator instructions.


### PR DESCRIPTION
Removed a note around workforce and composer instructions not being included in the doc