### PR TITLE
Document current ADOC country approval flow

### DIFF
--- a/adoc/flows/SalesOrders/OrderApproval.md
+++ b/adoc/flows/SalesOrders/OrderApproval.md
@@ -1,87 +1,168 @@
 ---
 description: >-
-  Learn about the two-step order approval process at ADOC, ensuring orders are
-  processed for fulfillment only if they meet specific criteria for updated
-  customer information and shipping addresses.
+  Learn how ADOC validates Shopify order attributes, enriches shipping
+  addresses, and approves orders during country-specific imports.
 ---
 
 # Order Approval
 
-Order approval in ADOC involves a two-step process. Initially, the shipping address is updated through an API call, and subsequently, a new order attribute named “SHIPTO\_ADDRESS\_UPDATED” is generated with a value of “true” after the address update. Orders qualify for approval only if they possess order attributes for both a government mandated Customer ID and SHIPTO\_ADDRESS\_UPDATED. This two-criteria condition ensures that only orders with both updated customer information and shipping addresses are processed for fulfillment.
+ADOC approves eligible Shopify orders as part of the real-time order import. The
+country-specific Maarg service transforms the Shopify order before it calls the
+standard Shopify order sync service. The transformation enriches the shipping
+address when required and sets `autoApprove` to control whether the OMS should
+approve the order after creating it.
 
-## Sync Shopify order metafields
+This flow is used for Costa Rica, Guatemala, Honduras, Nicaragua, Panama, and El
+Salvador. It replaces the older post-import flow that synchronized metafields,
+updated addresses in a later batch, and then queued orders for a scheduled
+approval job.
 
-After an order is imported, ADOC has a job enabled for importing order metafields, under the namespace “HotwaxOrderDetails”, from Shopify by an independent job as Order Attributes in HotWax Commerce.
+## Import and approval sequence
 
-A job in HotWax syncs order metafields from Shopify and saves them in HotWax as order attributes against that order.
+1. The `SYNC_SHOPIFY_ORDER` Data Manager configuration invokes the service for
+   the country where the Maarg instance is deployed.
+2. The country service executes its `OrderTransformation_<country>.groovy`
+   script against the Shopify GraphQL order payload.
+3. The script validates the country-specific note attributes, copies an
+   available phone number to the shipping and billing addresses, and enriches
+   the shipping address where required.
+4. The script sets `autoApprove` to `Y` when the order meets the applicable
+   rules. Otherwise, it remains `N`.
+5. The transformed payload is passed to the standard Shopify order sync
+   service. After `create#SalesOrder`, the OMS calls `approve#Order`. Approval
+   still depends on the product store, payment, and order-level approval
+   settings in the OMS.
 
-```
-Import Order Metafield
-```
+The implementation is in the `adoc-maarg` component. The country services are
+defined in
+`service/co/hotwax/adoc/order/ShopifyOrderServices.xml`. Their scripts are in
+`src/main/groovy/co/hotwax/order/transformation/`.
 
-This job specifically checks order metafields under the following namespace.
-
-```
-HotwaxOrderDetails
-```
-
-This job also has an optional buffer parameter that can be used to skip orders created less than a certain duration ago. For example, setting the buffer time of 60 minutes will exclude orders that were created in the last 60 minutes.
-
-{% hint style="info" %}
-```
-Buffer time is set in minutes
-```
-{% endhint %}
-
-To verify the sync is running as expected, use the Shopify GraphQL MDM. This page is located under MDM > EXIM > Shopify Jobs > Shopify GraphQL Job.
-
-Shopify GrqphQL config
-
-> Import Shopify Order Metafields.
-
-The municipio name in Shopify is stored as a Metafield upon order creation, which later becomes an order attribute in HotWax Commerce. To ensure accurate shipping, this order attribute must be transferred to both the City and Zipcode fields in the shipping address before sending it to the carrier.
-
-## Enrich shipping address
-
-HotWax updates the address by utilizing the `updatePostalAddressContactMech` API. After a successful order address update is completed, a new order attribute “SHIP\_TO\_ADDRESS\_UPDATED” is added to orders with the corrected address. This systematic approach ensures that the city information is correctly reflected in the shipping details provided to the carrier.
-
-Here is a step by step process of how HotWax validates if the address values stored in order attributes are valid before adding them to the shipping address of the order.
-
-A schedule process identifies all orders that do not have the `SHIP_TO_ADDRESS_UPDATED` attribute. The job then checks the order for either of the following attributes:
-
-* Municipio
-* Canton
-
-It then checks the value of this attribute against the `CarrierGeoMapping` records. If the job is able to successfully identify a match in the `GeoName` column with the expected carrier ID, then it takes the matching value and adds it to the order’s postal address.
-
-Once the job receives a successful response that the address has been updated in the OMS, the order ID is added to a file containing orders with successfully updated order attributes and the value of the new attribute that is to be added to them. After a batch of orders is complete, this file is imported by HotWax, and the orders have their attributes added to them. Now when a check for order approval is run in HotWax, it will verify that all the attributes are added to the order and then the order is approved for fulfillment.
-
-### Handling values that do not have a valid carrier code mapping
-
-We created a list of Municipios and Cantons where Shopify’s mapping was not aligned with what the shipping carriers were expecting. This meant that even though customers thought they were choosing the right value, behind the scenes on Shopify the ID of their selection was not what the actual carriers were expecting.
-
-To resolve this we manually mapped all the wrong values against what the right values should be for all the countries, and then added those mappings to the `CarrierGeoMapping` table and set their carrier to the system default carrier. These records have the expected erroneous mapping in the `GeoName` column with the corrected value in the `CarrierGeoValue` column. Now that the value is corrected, when shipping labels are requested by HotWax to the carriers, it's able to send the correct carrier code.
-
-If the job finds a matching value but the carrier is “NA”, otherwise known as the system default carrier, then it updates the postal address of the order with the data in the `CarrierGeoValue` column.
-
-The process of address correction does not, however, offer a fix for CSRs misspelling municipio and canton names while creating orders. Because the error in spelling is not predictable, there is no way to auto-correct them using this mapping methodology.
+| Country | Import service | Transformation script |
+| --- | --- | --- |
+| Costa Rica | `sync#ShopifyOrderForAdocCR` | `OrderTransformation_CR.groovy` |
+| Guatemala | `sync#ShopifyOrderForAdocGT` | `OrderTransformation_GT.groovy` |
+| Honduras | `sync#ShopifyOrderForAdocHN` | `OrderTransformation_HN.groovy` |
+| Nicaragua | `sync#ShopifyOrderForAdocNI` | `OrderTransformation_NI.groovy` |
+| Panama | `sync#ShopifyOrderForAdocPA` | `OrderTransformation_PA.groovy` |
+| El Salvador | `sync#ShopifyOrderForAdocSV` | `OrderTransformation_SV.groovy` |
 
 {% hint style="info" %}
-If an order cannot be automatically handled, it requires manual correction of its order attributes by a user for HotWax approval against this value.
+The seed definition of `SYNC_SHOPIFY_ORDER` does not select a country service.
+Deployment data must set its `importServiceName` to the service for that
+country.
 {% endhint %}
 
-## Approve Order
+## Country-specific rules
 
-A scheduled process checks orders for two attributes:
+The transformations use Shopify note attributes. Attribute names are
+case-sensitive. The country differences are:
 
-1. “CustomerId”: (any value)
-2. “SHIP\_TO\_ADDRESS\_UPDATED”: (“true”)
+* **Costa Rica:** Requires `canton`. It sets the shipping city and postal code
+  to the canton.
+* **Guatemala:** Requires `municipio`. It sets the shipping city and postal code
+  to the municipio.
+* **Honduras:** Requires `municipio`; `department` is optional. It sets the
+  shipping city and postal code to the municipio. When the department maps to a
+  state Geo, it also sets the shipping province code.
+* **Nicaragua:** Requires `municipio`. It sets the shipping city and postal code
+  to the municipio.
+* **Panama:** Requires `distrito`, `corregimiento`, and `barrio`. It does not
+  replace the shipping city or postal code.
+* **El Salvador:** Requires `municipio`. It sets the shipping city and postal
+  code to the municipio.
 
-All orders that have these attributes are queued to be approved by the “Approve Orders” job.
+For Costa Rica, Guatemala, Honduras, Nicaragua, and El Salvador:
 
-Job details:
+* The geographic attribute shown above is required.
+* When `taxCredit?` is explicitly `false`, `customerId` is also required.
+* If the order has no custom attributes, the transformation adds
+  `ATTRIBUTES_MISSING=true`.
+* When the checks pass, the script enriches the address, adds
+  `SHIPTO_ADDRESS_UPDATED=true` and `APPROVE_ORDER=true`, and sets
+  `autoApprove=Y`.
 
+For Panama:
+
+* `distrito`, `corregimiento`, and `barrio` are all required.
+* When `taxCredit?` exists and is explicitly `false`, `customerId` is also
+  required.
+* If the required attributes are missing, the transformation adds
+  `MISSING_ATTRIBUTES=true`.
+* When the checks pass, it adds `APPROVE_ORDER=true` and sets `autoApprove=Y`.
+  Panama does not add `SHIPTO_ADDRESS_UPDATED` because this transformation does
+  not replace the city or postal code.
+
+`APPROVE_ORDER=true` is a diagnostic attribute that records the result of the
+standard country checks. It is not the control that triggers a later approval
+job. The current import flow uses `autoApprove`.
+
+## Store pickup exception
+
+A non-empty `_pickupstore` line-item attribute sets `autoApprove=Y` independently
+of the country-specific address checks. Empty `_pickupstore` attributes are
+removed from the payload.
+
+This means a store pickup order can be eligible for approval without
+`APPROVE_ORDER` or `SHIPTO_ADDRESS_UPDATED`. It can also retain a missing
+attribute diagnostic generated by the country transformation.
+
+## Honduras department mapping
+
+The Honduras transformation treats `department` as optional:
+
+* When `department` is missing, it adds `DEPARTMENT_MISSING=true`.
+* When a department value is present but does not match a `GEOT_STATE` Geo, it
+  adds `DEPARTMENT_NOT_FOUND=true`.
+* When the Geo is found, it copies the Geo ID to the shipping address province
+  code.
+
+Neither department diagnostic blocks approval. When the `municipio` and
+tax-credit/customer rules pass, the script still adds
+`SHIPTO_ADDRESS_UPDATED=true` and `APPROVE_ORDER=true`, and sets
+`autoApprove=Y`.
+
+## Carrier assignment is separate
+
+Address enrichment during order import does not use `CarrierGeoMapping`.
+Carrier assignment is a later, separate process implemented by
+`assign#CarrierBasedOnMetroRule` in
+`service/co/hotwax/adoc/order/CarrierAssignmentServices.xml`. It uses `Geo` and
+`GeoAssoc` records for `METRO_AREA` relationships, skips store pickup orders,
+and records a system note when it cannot find the required geographic mapping.
+
+## Verify the flow
+
+Use a count query in Grafana to confirm activity without returning complete
+order payloads:
+
+```logql
+sum by (instance) (
+  count_over_time(
+    {instance=~"adoc-(cr|gt|hn|ni|pa|sv)-maarg-hotwax-io"}
+      |= "APPROVE_ORDER" [24h]
+  )
+)
 ```
-Approve orders
-ConfigId: IMP_APR_SALES_ORD
+
+Use `SHIPTO_ADDRESS_UPDATED` instead of `APPROVE_ORDER` to verify address
+enrichment. Results are expected for Costa Rica, Guatemala, Honduras,
+Nicaragua, and El Salvador, but not for Panama.
+
+For import errors, search for the deployed country service:
+
+```logql
+{instance=~"adoc-(cr|gt|hn|ni|pa|sv)-maarg-hotwax-io"}
+  |= "ShopifyOrderForAdoc"
 ```
+
+When an order has `APPROVE_ORDER=true` but is not approved, check the OMS order
+status and approval prerequisites. The `approve#Order` service also evaluates
+the product store's auto-approval setting, the order's `autoApprove` value, and
+payment-related settings.
+
+{% hint style="warning" %}
+Do not use the old `IMP_APR_SALES_ORD` scheduled-job procedure to diagnose the
+standard Maarg import flow. The legacy `approveSalesOrder` service can still be
+invoked separately, but it is not the approval mechanism described here.
+{% endhint %}

--- a/adoc/flows/SalesOrders/OrderApproval.md
+++ b/adoc/flows/SalesOrders/OrderApproval.md
@@ -1,42 +1,22 @@
 ---
-description: >-
-  Learn how ADOC validates Shopify order attributes, enriches shipping
-  addresses, and approves orders during country-specific imports.
+description: Learn how ADOC validates Shopify order attributes, enriches shipping addresses, and approves orders during country-specific imports.
 ---
 
 # Order Approval
 
-ADOC approves eligible Shopify orders as part of the real-time order import. The
-country-specific Maarg service transforms the Shopify order before it calls the
-standard Shopify order sync service. The transformation enriches the shipping
-address when required and sets `autoApprove` to control whether the OMS should
-approve the order after creating it.
+ADOC approves eligible Shopify orders as part of the real-time order import. The country-specific Maarg service transforms the Shopify order before it calls the standard Shopify order sync service. The transformation enriches the shipping address when required and sets `autoApprove` to control whether the OMS should approve the order after creating it.
 
-This flow is used for Costa Rica, Guatemala, Honduras, Nicaragua, Panama, and El
-Salvador. It replaces the older post-import flow that synchronized metafields,
-updated addresses in a later batch, and then queued orders for a scheduled
-approval job.
+This flow is used for Costa Rica, Guatemala, Honduras, Nicaragua, Panama, and El Salvador. It replaces the older post-import flow that synchronized metafields, updated addresses in a later batch, and then queued orders for a scheduled approval job.
 
 ## Import and approval sequence
 
-1. The `SYNC_SHOPIFY_ORDER` Data Manager configuration invokes the service for
-   the country where the Maarg instance is deployed.
-2. The country service executes its `OrderTransformation_<country>.groovy`
-   script against the Shopify GraphQL order payload.
-3. The script validates the country-specific note attributes, copies an
-   available phone number to the shipping and billing addresses, and enriches
-   the shipping address where required.
-4. The script sets `autoApprove` to `Y` when the order meets the applicable
-   rules. Otherwise, it remains `N`.
-5. The transformed payload is passed to the standard Shopify order sync
-   service. After `create#SalesOrder`, the OMS calls `approve#Order`. Approval
-   still depends on the product store, payment, and order-level approval
-   settings in the OMS.
+1. The `SYNC_SHOPIFY_ORDER` Data Manager configuration invokes the service for the country where the Maarg instance is deployed.
+2. The country service executes its `OrderTransformation_<country>.groovy` script against the Shopify GraphQL order payload.
+3. The script validates the country-specific note attributes, copies an available phone number to the shipping and billing addresses, and enriches the shipping address where required.
+4. The script sets `autoApprove` to `Y` when the order meets the applicable rules. Otherwise, it remains `N`.
+5. The transformed payload is passed to the standard Shopify order sync service. After `create#SalesOrder`, the OMS calls `approve#Order`. Approval still depends on the product store, payment, and order-level approval settings in the OMS.
 
-The implementation is in the `adoc-maarg` component. The country services are
-defined in
-`service/co/hotwax/adoc/order/ShopifyOrderServices.xml`. Their scripts are in
-`src/main/groovy/co/hotwax/order/transformation/`.
+The implementation is in the `adoc-maarg` component. The country services are defined in `service/co/hotwax/adoc/order/ShopifyOrderServices.xml`. Their scripts are in `src/main/groovy/co/hotwax/order/transformation/`.
 
 | Country | Import service | Transformation script |
 | --- | --- | --- |
@@ -48,93 +28,59 @@ defined in
 | El Salvador | `sync#ShopifyOrderForAdocSV` | `OrderTransformation_SV.groovy` |
 
 {% hint style="info" %}
-The seed definition of `SYNC_SHOPIFY_ORDER` does not select a country service.
-Deployment data must set its `importServiceName` to the service for that
-country.
+The seed definition of `SYNC_SHOPIFY_ORDER` does not select a country service. Deployment data must set its `importServiceName` to the service for that country.
 {% endhint %}
 
 ## Country-specific rules
 
-The transformations use Shopify note attributes. Attribute names are
-case-sensitive. The country differences are:
+The transformations use Shopify note attributes. Attribute names are case-sensitive. The country differences are:
 
-* **Costa Rica:** Requires `canton`. It sets the shipping city and postal code
-  to the canton.
-* **Guatemala:** Requires `municipio`. It sets the shipping city and postal code
-  to the municipio.
-* **Honduras:** Requires `municipio`; `department` is optional. It sets the
-  shipping city and postal code to the municipio. When the department maps to a
-  state Geo, it also sets the shipping province code.
-* **Nicaragua:** Requires `municipio`. It sets the shipping city and postal code
-  to the municipio.
-* **Panama:** Requires `distrito`, `corregimiento`, and `barrio`. It does not
-  replace the shipping city or postal code.
-* **El Salvador:** Requires `municipio`. It sets the shipping city and postal
-  code to the municipio.
+* **Costa Rica:** Requires `canton`. It sets the shipping city and postal code to the canton.
+* **Guatemala:** Requires `municipio`. It sets the shipping city and postal code to the municipio.
+* **Honduras:** Requires `municipio`; `department` is optional. It sets the shipping city and postal code to the municipio. When the department maps to a state Geo, it also sets the shipping province code.
+* **Nicaragua:** Requires `municipio`. It sets the shipping city and postal code to the municipio.
+* **Panama:** Requires `distrito`, `corregimiento`, and `barrio`. It does not replace the shipping city or postal code.
+* **El Salvador:** Requires `municipio`. It sets the shipping city and postal code to the municipio.
 
 For Costa Rica, Guatemala, Honduras, Nicaragua, and El Salvador:
 
 * The geographic attribute shown above is required.
 * When `taxCredit?` is explicitly `false`, `customerId` is also required.
-* If the order has no custom attributes, the transformation adds
-  `ATTRIBUTES_MISSING=true`.
-* When the checks pass, the script enriches the address, adds
-  `SHIPTO_ADDRESS_UPDATED=true` and `APPROVE_ORDER=true`, and sets
-  `autoApprove=Y`.
+* If the order has no custom attributes, the transformation adds `ATTRIBUTES_MISSING=true`.
+* When the checks pass, the script enriches the address, adds `SHIPTO_ADDRESS_UPDATED=true` and `APPROVE_ORDER=true`, and sets `autoApprove=Y`.
 
 For Panama:
 
 * `distrito`, `corregimiento`, and `barrio` are all required.
-* When `taxCredit?` exists and is explicitly `false`, `customerId` is also
-  required.
-* If the required attributes are missing, the transformation adds
-  `MISSING_ATTRIBUTES=true`.
-* When the checks pass, it adds `APPROVE_ORDER=true` and sets `autoApprove=Y`.
-  Panama does not add `SHIPTO_ADDRESS_UPDATED` because this transformation does
-  not replace the city or postal code.
+* When `taxCredit?` exists and is explicitly `false`, `customerId` is also required.
+* If the required attributes are missing, the transformation adds `MISSING_ATTRIBUTES=true`.
+* When the checks pass, it adds `APPROVE_ORDER=true` and sets `autoApprove=Y`. Panama does not add `SHIPTO_ADDRESS_UPDATED` because this transformation does not replace the city or postal code.
 
-`APPROVE_ORDER=true` is a diagnostic attribute that records the result of the
-standard country checks. It is not the control that triggers a later approval
-job. The current import flow uses `autoApprove`.
+`APPROVE_ORDER=true` is a diagnostic attribute that records the result of the standard country checks. It is not the control that triggers a later approval job. The current import flow uses `autoApprove`.
 
 ## Store pickup exception
 
-A non-empty `_pickupstore` line-item attribute sets `autoApprove=Y` independently
-of the country-specific address checks. Empty `_pickupstore` attributes are
-removed from the payload.
+A non-empty `_pickupstore` line-item attribute sets `autoApprove=Y` independently of the country-specific address checks. Empty `_pickupstore` attributes are removed from the payload.
 
-This means a store pickup order can be eligible for approval without
-`APPROVE_ORDER` or `SHIPTO_ADDRESS_UPDATED`. It can also retain a missing
-attribute diagnostic generated by the country transformation.
+This means a store pickup order can be eligible for approval without `APPROVE_ORDER` or `SHIPTO_ADDRESS_UPDATED`. It can also retain a missing attribute diagnostic generated by the country transformation.
 
 ## Honduras department mapping
 
 The Honduras transformation treats `department` as optional:
 
 * When `department` is missing, it adds `DEPARTMENT_MISSING=true`.
-* When a department value is present but does not match a `GEOT_STATE` Geo, it
-  adds `DEPARTMENT_NOT_FOUND=true`.
-* When the Geo is found, it copies the Geo ID to the shipping address province
-  code.
+* When a department value is present but does not match a `GEOT_STATE` Geo, it adds `DEPARTMENT_NOT_FOUND=true`.
+* When the Geo is found, it copies the Geo ID to the shipping address province code.
 
-Neither department diagnostic blocks approval. When the `municipio` and
-tax-credit/customer rules pass, the script still adds
-`SHIPTO_ADDRESS_UPDATED=true` and `APPROVE_ORDER=true`, and sets
-`autoApprove=Y`.
+Neither department diagnostic blocks approval. When the `municipio` and tax-credit/customer rules pass, the script still adds `SHIPTO_ADDRESS_UPDATED=true` and `APPROVE_ORDER=true`, and sets `autoApprove=Y`.
 
 ## Carrier assignment is separate
 
-Address enrichment during order import does not use `CarrierGeoMapping`.
-Carrier assignment is a later, separate process implemented by
-`assign#CarrierBasedOnMetroRule` in
-`service/co/hotwax/adoc/order/CarrierAssignmentServices.xml`. It uses `Geo` and
-`GeoAssoc` records for `METRO_AREA` relationships, skips store pickup orders,
-and records a system note when it cannot find the required geographic mapping.
+Address enrichment during order import does not use `CarrierGeoMapping`. Carrier assignment is a later, separate process implemented by `assign#CarrierBasedOnMetroRule` in `service/co/hotwax/adoc/order/CarrierAssignmentServices.xml`. It uses `Geo` and `GeoAssoc` records for `METRO_AREA` relationships, skips store pickup orders, and records a system note when it cannot find the required geographic mapping.
 
 ## Verify the flow
 
-Use a count query in Grafana to confirm activity without returning complete
-order payloads:
+Use a count query in Grafana to confirm activity without returning complete order payloads:
 
 ```logql
 sum by (instance) (
@@ -145,9 +91,7 @@ sum by (instance) (
 )
 ```
 
-Use `SHIPTO_ADDRESS_UPDATED` instead of `APPROVE_ORDER` to verify address
-enrichment. Results are expected for Costa Rica, Guatemala, Honduras,
-Nicaragua, and El Salvador, but not for Panama.
+Use `SHIPTO_ADDRESS_UPDATED` instead of `APPROVE_ORDER` to verify address enrichment. Results are expected for Costa Rica, Guatemala, Honduras, Nicaragua, and El Salvador, but not for Panama.
 
 For import errors, search for the deployed country service:
 
@@ -156,13 +100,8 @@ For import errors, search for the deployed country service:
   |= "ShopifyOrderForAdoc"
 ```
 
-When an order has `APPROVE_ORDER=true` but is not approved, check the OMS order
-status and approval prerequisites. The `approve#Order` service also evaluates
-the product store's auto-approval setting, the order's `autoApprove` value, and
-payment-related settings.
+When an order has `APPROVE_ORDER=true` but is not approved, check the OMS order status and approval prerequisites. The `approve#Order` service also evaluates the product store's auto-approval setting, the order's `autoApprove` value, and payment-related settings.
 
 {% hint style="warning" %}
-Do not use the old `IMP_APR_SALES_ORD` scheduled-job procedure to diagnose the
-standard Maarg import flow. The legacy `approveSalesOrder` service can still be
-invoked separately, but it is not the approval mechanism described here.
+Do not use the old `IMP_APR_SALES_ORD` scheduled-job procedure to diagnose the standard Maarg import flow. The legacy `approveSalesOrder` service can still be invoked separately, but it is not the approval mechanism described here.
 {% endhint %}

--- a/adoc/troubleshooting/orderApproval.md
+++ b/adoc/troubleshooting/orderApproval.md
@@ -1,19 +1,14 @@
 ---
-description: >-
-  Troubleshoot ADOC country transformations, approval diagnostics, and OMS
-  approval prerequisites for Shopify orders.
+description: Troubleshoot ADOC country transformations, approval diagnostics, and OMS approval prerequisites for Shopify orders.
 ---
 
 # Troubleshoot Order Approval
 
-ADOC normally validates and approves eligible Shopify orders during real-time
-import. Start with the [Order Approval](../flows/SalesOrders/OrderApproval.md)
-flow to identify the rules for the country being investigated.
+ADOC normally validates and approves eligible Shopify orders during real-time import. Start with the [Order Approval](../flows/SalesOrders/OrderApproval.md) flow to identify the rules for the country being investigated.
 
 ## Confirm the country importer
 
-The `SYNC_SHOPIFY_ORDER` Data Manager configuration must use the service for the
-deployed country:
+The `SYNC_SHOPIFY_ORDER` Data Manager configuration must use the service for the deployed country:
 
 | Country | Expected service |
 | --- | --- |
@@ -24,8 +19,7 @@ deployed country:
 | Panama | `sync#ShopifyOrderForAdocPA` |
 | El Salvador | `sync#ShopifyOrderForAdocSV` |
 
-Search the Maarg logs for the country service to confirm that the order reached
-the transformation:
+Search the Maarg logs for the country service to confirm that the order reached the transformation:
 
 ```logql
 {instance="adoc-<country>-maarg-hotwax-io"}
@@ -36,53 +30,35 @@ Replace `<country>` with `cr`, `gt`, `hn`, `ni`, `pa`, or `sv`.
 
 ## Interpret diagnostic attributes
 
-Check the order attributes and the country-specific Shopify note attributes.
-Attribute names are case-sensitive.
+Check the order attributes and the country-specific Shopify note attributes. Attribute names are case-sensitive.
 
-* `ATTRIBUTES_MISSING=true` means a CR, GT, HN, NI, or SV payload did not
-  contain custom attributes. The standard country approval checks did not pass.
-* `MISSING_ATTRIBUTES=true` means a PA payload is missing `distrito`,
-  `corregimiento`, or `barrio`. The standard country approval checks did not
-  pass.
-* `DEPARTMENT_MISSING=true` means HN did not receive a department. This is a
-  warning only and does not block approval.
-* `DEPARTMENT_NOT_FOUND=true` means the HN department did not map to a state
-  Geo. This is a warning only and does not block approval.
-* `SHIPTO_ADDRESS_UPDATED=true` confirms that CR, GT, HN, NI, or SV copied its
-  geographic value into the shipping city and postal code. PA does not use this
-  attribute.
-* `APPROVE_ORDER=true` means the standard country checks passed. It is
-  diagnostic only; the current approval flow is controlled by `autoApprove`.
+* `ATTRIBUTES_MISSING=true` means a CR, GT, HN, NI, or SV payload did not contain custom attributes. The standard country approval checks did not pass.
+* `MISSING_ATTRIBUTES=true` means a PA payload is missing `distrito`, `corregimiento`, or `barrio`. The standard country approval checks did not pass.
+* `DEPARTMENT_MISSING=true` means HN did not receive a department. This is a warning only and does not block approval.
+* `DEPARTMENT_NOT_FOUND=true` means the HN department did not map to a state Geo. This is a warning only and does not block approval.
+* `SHIPTO_ADDRESS_UPDATED=true` confirms that CR, GT, HN, NI, or SV copied its geographic value into the shipping city and postal code. PA does not use this attribute.
+* `APPROVE_ORDER=true` means the standard country checks passed. It is diagnostic only; the current approval flow is controlled by `autoApprove`.
 
-For CR, GT, HN, NI, and SV, verify the required `canton` or `municipio`.
-For PA, verify `distrito`, `corregimiento`, and `barrio`. When `taxCredit?` is
-explicitly `false`, also verify that `customerId` is present.
+For CR, GT, HN, NI, and SV, verify the required `canton` or `municipio`. For PA, verify `distrito`, `corregimiento`, and `barrio`. When `taxCredit?` is explicitly `false`, also verify that `customerId` is present.
 
 ## Check the store pickup exception
 
-A non-empty `_pickupstore` line-item attribute sets `autoApprove=Y` independently
-of the address checks. An order can therefore be approved for store pickup even
-when `APPROVE_ORDER` or `SHIPTO_ADDRESS_UPDATED` is absent. Empty
-`_pickupstore` attributes are discarded.
+A non-empty `_pickupstore` line-item attribute sets `autoApprove=Y` independently of the address checks. An order can therefore be approved for store pickup even when `APPROVE_ORDER` or `SHIPTO_ADDRESS_UPDATED` is absent. Empty `_pickupstore` attributes are discarded.
 
 ## Confirm the OMS approval result
 
-After creating the sales order, the OMS calls `approve#Order`. If the order
-remains in `ORDER_CREATED` or `ORDER_HOLD`, check:
+After creating the sales order, the OMS calls `approve#Order`. If the order remains in `ORDER_CREATED` or `ORDER_HOLD`, check:
 
 1. The product store has auto-approval enabled.
 2. The order's `autoApprove` value is not `N`.
 3. The payment method satisfies the store's approval-without-payment setting.
-4. The Maarg and OMS logs do not contain an approval or allocation error for
-   the order.
+4. The Maarg and OMS logs do not contain an approval or allocation error for the order.
 
-`APPROVE_ORDER=true` alone does not prove that the OMS approved the order.
-Confirm the final order status.
+`APPROVE_ORDER=true` alone does not prove that the OMS approved the order. Confirm the final order status.
 
 ## Use privacy-safe Grafana checks
 
-Use count queries for routine monitoring so that complete customer payloads are
-not returned:
+Use count queries for routine monitoring so that complete customer payloads are not returned:
 
 ```logql
 sum by (instance) (
@@ -104,6 +80,4 @@ sum(
 )
 ```
 
-The older NiFi metafield feed, `CarrierGeoMapping` address-correction batch, and
-`IMP_APR_SALES_ORD` scheduled approval job are not part of this standard Maarg
-import path.
+The older NiFi metafield feed, `CarrierGeoMapping` address-correction batch, and `IMP_APR_SALES_ORD` scheduled approval job are not part of this standard Maarg import path.

--- a/adoc/troubleshooting/orderApproval.md
+++ b/adoc/troubleshooting/orderApproval.md
@@ -1,76 +1,109 @@
 ---
 description: >-
-  Learn about the order approval process at ADOC, including address validation
-  and the requirement for a government-mandated Customer ID, with a focus on
-  importing order metafields from Shopify to HC.
+  Troubleshoot ADOC country transformations, approval diagnostics, and OMS
+  approval prerequisites for Shopify orders.
 ---
 
-# Order Approval
+# Troubleshoot Order Approval
 
-ADOC uses a custom flow where certain orders are only approved after the address is validated and a government-mandated Customer ID is present. After an order is imported, ADOC has a job enabled for importing order metafields, under the namespace “HotwaxOrderDetails”, from Shopify by an independent job as Order Attributes in HotWax Commerce.
+ADOC normally validates and approves eligible Shopify orders during real-time
+import. Start with the [Order Approval](../flows/SalesOrders/OrderApproval.md)
+flow to identify the rules for the country being investigated.
 
-## Sync metafields from Shopify
+## Confirm the country importer
 
-To synchronize order meta fields from Shopify, we have configured a workflow that utilizes NiFi custom flows and Moqui Services.
-The process can be divided into four main steps:
+The `SYNC_SHOPIFY_ORDER` Data Manager configuration must use the service for the
+deployed country:
 
-1. **Preparing File for Shopify API Request**:
-   NiFi fetches all orders from the database that lack the required meta fields: `customerId` and `municipio`. The dataset with missing meta fields is converted into a JSON file suitable for a Shopify API request and kept on this FTP location-
-    ```
-   /home/{sftp-username}/hotwax/shopify/CreatedOrderIdsFeed
-    ```
+| Country | Expected service |
+| --- | --- |
+| Costa Rica | `sync#ShopifyOrderForAdocCR` |
+| Guatemala | `sync#ShopifyOrderForAdocGT` |
+| Honduras | `sync#ShopifyOrderForAdocHN` |
+| Nicaragua | `sync#ShopifyOrderForAdocNI` |
+| Panama | `sync#ShopifyOrderForAdocPA` |
+| El Salvador | `sync#ShopifyOrderForAdocSV` |
 
+Search the Maarg logs for the country service to confirm that the order reached
+the transformation:
 
-2. **Shopify API Call**:
-   A job scheduled in on maarg instance poll_OMSOrderIdsFeed_{brandName} picks the above created file and calls the Shopify API to obtain the current meta fields under the namespace "HotwaxOrderDetails". The response from Shopify is received in JSON format and placed at FTP location-
-    ```
-   /home/{sftp_username}/hotwax/shopify/OrdersMetaFieldsFeed
-    ```
+```logql
+{instance="adoc-<country>-maarg-hotwax-io"}
+  |= "ShopifyOrderForAdoc"
+```
 
+Replace `<country>` with `cr`, `gt`, `hn`, `ni`, `pa`, or `sv`.
 
-3. **Transformation of API Response**:
-   The JSON response from Shopify is not directly understandable by the OMS. NiFi processes this JSON file to convert it into a format that OMS can accept, and places the file on FTP location-
-    ```
-   /home/{sftp_username}/hotwax/oms/ImportJsonListData
-   ```
+## Interpret diagnostic attributes
 
+Check the order attributes and the country-specific Shopify note attributes.
+Attribute names are case-sensitive.
 
-4. **Job Picking and Data Import**:
-   The transformed file is placed in an FTP location for OMS. The "Packaged Multi-Stream Import" job, located in the Miscellaneous section of the job manager app, retrieves the file and imports the data into OMS.
+* `ATTRIBUTES_MISSING=true` means a CR, GT, HN, NI, or SV payload did not
+  contain custom attributes. The standard country approval checks did not pass.
+* `MISSING_ATTRIBUTES=true` means a PA payload is missing `distrito`,
+  `corregimiento`, or `barrio`. The standard country approval checks did not
+  pass.
+* `DEPARTMENT_MISSING=true` means HN did not receive a department. This is a
+  warning only and does not block approval.
+* `DEPARTMENT_NOT_FOUND=true` means the HN department did not map to a state
+  Geo. This is a warning only and does not block approval.
+* `SHIPTO_ADDRESS_UPDATED=true` confirms that CR, GT, HN, NI, or SV copied its
+  geographic value into the shipping city and postal code. PA does not use this
+  attribute.
+* `APPROVE_ORDER=true` means the standard country checks passed. It is
+  diagnostic only; the current approval flow is controlled by `autoApprove`.
 
-#### To ensure the job runs properly, we need to verify the following:
-1. The corresponding custom NiFi flow is properly schedule and running on respective NiFi instance.
-2. Go to the respective maarg instance e.g. https://adoc-sv-maarg-uat.hotwax.io
-3. After logging in with valid credentials, click on System, then select Service Job.
-4. Search for job poll_OMSOrderIdsFeed_{brandName}, check if the job is set up properly and having **paused** value as 'N'
+For CR, GT, HN, NI, and SV, verify the required `canton` or `municipio`.
+For PA, verify `distrito`, `corregimiento`, and `barrio`. When `taxCredit?` is
+explicitly `false`, also verify that `customerId` is present.
 
-If the metafield sync is running as expected, on the order detail page these attributes should be present:
+## Check the store pickup exception
 
-1. Customer ID
-2. Municipio
-3. SHIPTO\_ADDRESS\_UPDATED: true
+A non-empty `_pickupstore` line-item attribute sets `autoApprove=Y` independently
+of the address checks. An order can therefore be approved for store pickup even
+when `APPROVE_ORDER` or `SHIPTO_ADDRESS_UPDATED` is absent. Empty
+`_pickupstore` attributes are discarded.
 
-The `SHIPTO_ADDRESS_UPDATED` order attribute is created after an order has been first validated for a registered Municipio order attribute value. If this attribute is not created, that means that the order does not have a valid Municipio attribute and one needs to be added.
+## Confirm the OMS approval result
 
-Validate that the Order Item Attribute job for this is enabled.
+After creating the sales order, the OMS calls `approve#Order`. If the order
+remains in `ORDER_CREATED` or `ORDER_HOLD`, check:
 
-Validate that the config ID is set correctly. The default config ID is: `IMP_ORDER_ITM_ATTR`
+1. The product store has auto-approval enabled.
+2. The order's `autoApprove` value is not `N`.
+3. The payment method satisfies the store's approval-without-payment setting.
+4. The Maarg and OMS logs do not contain an approval or allocation error for
+   the order.
 
-You can use the “Missing Order Attribute” report to identify orders where the OMS could not automatically correct the address of an order.
+`APPROVE_ORDER=true` alone does not prove that the OMS approved the order.
+Confirm the final order status.
 
-## Metafields created on Shopify but not imported into HotWax
+## Use privacy-safe Grafana checks
 
-1. Go to the Shopify order details page and append /metafields.json to the URL.
-2. Verify the order creation and metafields input time in the Shopify JSON.
-3. If you cannot wait for metafields to be imported or the job is not working as expected, order attributes can be created manually from the Order Detail page.
+Use count queries for routine monitoring so that complete customer payloads are
+not returned:
 
-Mapping Central American region types to the OMS's North American Region types helps when troubleshooting order approval flows in the OMS. If the address entered into the order is not mapped correctly to the type of region, then the order will not be approved even if the region name exists.
+```logql
+sum by (instance) (
+  count_over_time(
+    {instance=~"adoc-(cr|gt|hn|ni|pa|sv)-maarg-hotwax-io"}
+      |= "APPROVE_ORDER" [24h]
+  )
+)
+```
 
-| Central American Region | North American Region Type |
-| ----------------------- | -------------------------- |
-| Departamento            | State                      |
-| Municipio               | Municipality               |
-| Canton                  | Canton                     |
-| Distrito                | District                   |
+For Honduras department warnings:
 
-Read [the Glossary](../GLOSSARY.md) to learn more about how the Central American Regions maps to the Carrier Geo Mapping entries in the OMS.
+```logql
+sum(
+  count_over_time(
+    {instance="adoc-hn-maarg-hotwax-io"}
+      |~ "DEPARTMENT_(MISSING|NOT_FOUND)" [24h]
+  )
+)
+```
+
+The older NiFi metafield feed, `CarrierGeoMapping` address-correction batch, and
+`IMP_APR_SALES_ORD` scheduled approval job are not part of this standard Maarg
+import path.


### PR DESCRIPTION
Supersedes #1237. Its fork branch does not allow maintainer edits, so this replacement starts from the current `implementations-pub` branch.

## What changed

- Documents the six country-specific Maarg import services and transformation scripts.
- Explains that `autoApprove`, not a later `APPROVE_ORDER` scan, controls the standard import-time approval attempt.
- Records the distinct CR, GT, HN, NI, PA, and SV geographic rules.
- Clarifies the store-pickup exception and that HN department mapping is diagnostic, not an approval gate.
- Separates current metro-based carrier assignment from address enrichment.
- Replaces the obsolete NiFi/metafield/FTP troubleshooting procedure with current country-service, attribute, OMS, and privacy-safe Grafana checks.

## Source verification

### Current code

- `hotwax/adoc-maarg/service/co/hotwax/adoc/order/ShopifyOrderServices.xml`
- `hotwax/adoc-maarg/src/main/groovy/co/hotwax/order/transformation/OrderTransformation_{CR,GT,HN,NI,PA,SV}.groovy`
- `hotwax/adoc-maarg/service/co/hotwax/adoc/order/CarrierAssignmentServices.xml`
- `hotwax/oms/service/oms.secas.xml` (`create#SalesOrder` -> `approve#Order`)
- `hotwax/oms/service/co/hotwax/oms/order/OrderServices.xml` (product-store, order-level, and payment approval gates)

### Google Chat

- Delivery Management monitoring, 2026-07-31 11:45 IST: the same current Data Manager failure signature was seen across all six ADOC country instances in one shared job window. This corroborates the six-country deployment pattern; it is not used as proof of the approval rules.
- HC SCRUMs, 2026-07-30 23:39 IST: ADOC dashboards were being monitored and ADOC Maarg UAT was deployed on v5.5.11 for testing.
- Historical 2024 `SHIPTO_ADDRESS_UPDATED` messages describe the former post-import loop, which is why that procedure is removed here.

### Production Grafana/Loki

Privacy-safe `count_over_time` checks on 2026-07-31, last 7 days:

| Instance | `APPROVE_ORDER` lines | `SHIPTO_ADDRESS_UPDATED` lines |
| --- | ---: | ---: |
| CR | 312 | 312 |
| GT | 798 | 667 |
| HN | 170 | 170 |
| NI | 61 | 61 |
| PA | 30 | 0 |
| SV | 611 | 611 |

These are log-line occurrences, not order counts. The country service names also appear in deployed runtime stacks for all six instances. HN produced 5 `DEPARTMENT_MISSING` and 126 `DEPARTMENT_NOT_FOUND` lines in the last 30 days; PA produced 73 `MISSING_ATTRIBUTES` lines. No customer payloads or PII are copied into the documentation.

## Validation

- `markdownlint-cli --disable MD013`: 0 issues across both changed files
- Normalized-text comparison: wording unchanged; only hard wrapping was removed
- `git diff --check`: passed

Closes #1794