### PR TITLE
Link order routing from business process introduction

### DIFF
--- a/documents/learn-hotwax-oms/business-processes/README.md
+++ b/documents/learn-hotwax-oms/business-processes/README.md
@@ -9,6 +9,6 @@ description: >-
 
 * [**Order Fulfillment**](order-fulfillment.md)**:** This section delves into key stages involved in order fulfillment, including order allocation, picking, packing, and shipping. Learn about how each step is designed to maintain efficiency and accuracy in fulfilling customer orders.
 * [**Inventory Management**](inventory-management.md)**:** Here, we outline the strategies and practices used to manage inventory across the network. Learn about how inventory levels are monitored, updated, and synchronized with real-time data to ensure optimal stock availability and accurate fulfillment.
-* **Order Routing (Upcoming):** This part of the guide explains the mechanisms behind routing orders to the most optimal fulfillment locations. Learn about how HotWax Commerce utilizes intelligent logics and real-time data to route orders to warehouses or stores, ensuring timely and cost-effective deliveries.
+* [**Order Routing**](order-routing.md)**:** This part of the guide explains the mechanisms behind routing orders to the most optimal fulfillment locations. Learn about how HotWax Commerce utilizes intelligent logics and real-time data to route orders to warehouses or stores, ensuring timely and cost-effective deliveries.
 
 By exploring these processes, you will gain valuable insights into how HotWax Commerce supports streamlined omnichannel journeys, enabling you to deliver a cohesive and consistent customer experience across all sales channels.


### PR DESCRIPTION
## Problem

The Business Processes introduction still labels **Order Routing** as “Upcoming” even though PR #1874 published the page and added it to the navigation. The introduction also does not link to the published page.

## Change

- Remove the stale “Upcoming” label.
- Link **Order Routing** to `order-routing.md`, matching the adjacent business-process entries.

## User impact

Readers entering through the Business Processes introduction can open the published Order Routing guide and will no longer be told it is unreleased.

## Validation

- Confirmed `documents/learn-hotwax-oms/business-processes/order-routing.md` exists on `user-guides-pub`.
- Searched `documents/learn-hotwax-oms` for other stale Order Routing “Upcoming” references; none remain.
- `git diff --check`
- `markdownlint-cli2 documents/learn-hotwax-oms/business-processes/README.md` — 0 errors

Follow-up to #1874 and [review comment](https://github.com/hotwax/oms-documentation/pull/1874#discussion_r3690015113).