### PR TITLE
Add safety stock demo video to the current sourcing guide

### DIFF
--- a/documents/retail-operations/inventory/available-to-promise/safety-stock-rules.md
+++ b/documents/retail-operations/inventory/available-to-promise/safety-stock-rules.md
@@ -8,6 +8,11 @@ Safety stock reserves inventory at each affected facility so that quantity is no
 
 For example, if a facility has 100 units and a safety stock value of 10, the facility contributes at most 90 units before other deductions.
 
+<!-- markdownlint-disable-next-line MD034 -->
+{% embed url="https://drive.google.com/file/d/1ZVyzgP4IEKDQpXGusVvHfpAsj9ecdA09/view?usp=drive_link" %}
+Attribute-Based Safety Stock
+{% endembed %}
+
 ## Create a safety stock rule
 
 1. Open `Sourcing` > `Safety stock`.


### PR DESCRIPTION
## What changed

- Add Prakhar's Attribute-Based Safety Stock video to the current `Configure safety stock rules` page.
- Position the overview after the safety-stock example and before the current `Sourcing > Safety stock` procedure.
- Keep the source-verified terminology and impacted-facility guidance introduced by the routing and sourcing manual refresh.

## Why

The original contribution in #1836 targeted the retired ATP-era version of this page. The recording itself remains suitable because it focuses on facility groups, product tags, product features, and safety-stock behavior without relying on the retired app shell.

## Validation

- `git diff --check`
- Markdownlint: 0 issues
- Confirmed the Drive file is available and the embed uses GitBook syntax

Supersedes #1836 while preserving its video contribution.