### PR TITLE
Update shipping rules demo for the unified sourcing UI

### DIFF
--- a/documents/retail-operations/inventory/available-to-promise/shipping-rule.md
+++ b/documents/retail-operations/inventory/available-to-promise/shipping-rule.md
@@ -10,6 +10,11 @@ Open `Sourcing` > `Shipping` to manage shipping across three tabs:
 * `Product and channel`: Apply a product rule to inventory channels.
 * `Facility`: Set the fulfillment capacity for individual facilities.
 
+<!-- markdownlint-disable-next-line MD034 -->
+{% embed url="https://drive.google.com/file/d/1yKSHLP3DQczVdbvtWcjdWoynNCEKvpbU/view?usp=drive_link" %}
+Store and Product Fulfillment Rules
+{% endembed %}
+
 ## Set facility fulfillment capacity
 
 Fulfillment capacity limits how many orders can be allocated to a facility. It does not change the facility available-to-promise inventory.


### PR DESCRIPTION
## What changed

- Position the Store and Product Fulfillment Rules video directly after the three current `Sourcing > Shipping` tabs.
- Retain the current shipping-rule procedures for facility capacity, product-and-facility rules, and product-and-channel rules.

## Recording update required

The existing recording is included at its intended final location as a placeholder, but it still shows the retired **Available to Promise** app shell. Before this PR is ready to merge, replace it with a recording from the current **Order Routing Rules** app that shows:

- `Sourcing > Shipping` in the unified navigation;
- the `Product and facility`, `Product and channel`, and `Facility` tabs;
- `Facility Groups` and `Select all facility groups` on the rule form; and
- the impacted-facility count before saving.

## Validation

- `git diff --check`
- Markdownlint: 0 issues
- Confirmed the current Drive file is available and the embed uses GitBook syntax

Supersedes #1834 and preserves its intended documentation placement.