### PR TITLE
Update order-splitting demo for the current routing detail UI

### DIFF
--- a/documents/retail-operations/orders/order-routing/inventory-rules.md
+++ b/documents/retail-operations/orders/order-routing/inventory-rules.md
@@ -87,6 +87,11 @@ When the selected routing uses a `Promise date` filter, the app requires partial
 
 Allowing partial allocation can increase the number of shipments. Review your [additional routing settings](additional-settings.md) before you enable it.
 
+<!-- markdownlint-disable-next-line MD034 -->
+{% embed url="https://drive.google.com/file/d/1u6Y_aeR1NKF0iY-xrN5IJyMXzDbj-QKy/view?usp=drive_link" %}
+Order Splitting Controls
+{% endembed %}
+
 ## Configure unavailable-item actions
 
 Use the `Unavailable items` settings to decide what happens after a rule cannot allocate an item.


### PR DESCRIPTION
## What changed

- Move the Order Splitting Controls video to the current `Configure routing rules` guide under `Configure partial allocation`.
- Keep shipment-threshold guidance linked through `Additional routing settings`, because the recording covers both partial allocation and the threshold check.

## Recording update required

The existing recording is included at its intended final location as a placeholder, but it shows the retired `Routing` page, `Add Inventory Rule`, and the old floating save action. Before this PR is ready to merge, replace it with a recording that shows:

- opening a routing group from `Order Routing`;
- the current `Order Routing Detail` workspace;
- selecting or adding a **routing rule**;
- `Allow partial allocation`, `Partially allocate grouped items`, and `Shipment threshold check`; and
- the page-level `Save` that persists the routing-group working copy.

## Validation

- `git diff --check`
- Markdownlint: 0 issues
- Confirmed the current Drive file is available and the embed uses GitBook syntax

Supersedes #1835 and preserves its intended documentation placement.