### PR TITLE
Note that the starting NetSuite status depends on approval routing

### DIFF
--- a/documents/learn-hotwax-oms/business-process-models/transferorder-lifecycle.md
+++ b/documents/learn-hotwax-oms/business-process-models/transferorder-lifecycle.md
@@ -15,6 +15,10 @@ Transfer orders are created in the ERP system, they serve various purposes, incl
 
 To explain the Transfer Order Lifecycle BPM, we've opted NetSuite as the ERP system, Shopify for eCommerce, and HotWax Commerce for the OMS because most of our customers use this tech stack.
 
+{% hint style="info" %}
+The status a new transfer order receives in NetSuite depends on an accounting preference. It is either <mark style="color:orange;">**“Pending Approval”**</mark> or <mark style="color:orange;">**“Pending Fulfillment”**</mark>. This document assumes approval routing is turned off, so new transfer orders start in <mark style="color:orange;">**“Pending Fulfillment”**</mark>.
+{% endhint %}
+
 ## Warehouse to Store Transfer Orders
 
 <figure><img src="../.gitbook/assets/warehouse-to-store-transfer-orders-lifecycle-bpm.png" alt=""><figcaption><p>Warehouse to store transfer orders lifecycle business process model</p></figcaption></figure>


### PR DESCRIPTION
The page says a new transfer order is automatically assigned Pending Fulfillment.

NetSuite assigns either Pending Approval or Pending Fulfillment. It depends on an accounting preference.

Added one note stating the assumption this document makes.

Source: [Entering a Transfer Order](https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_N2310933.html)